### PR TITLE
Replace usage of Objects.equals (old Android support)

### DIFF
--- a/src/main/java/in/dragonbra/javasteam/types/GameID.java
+++ b/src/main/java/in/dragonbra/javasteam/types/GameID.java
@@ -1,6 +1,6 @@
 package in.dragonbra.javasteam.types;
 
-import java.util.Objects;
+import in.dragonbra.javasteam.util.compat.ObjectsCompat;
 
 /**
  * This 64bit structure represents an app, mod, shortcut, or p2p file on the Steam network.
@@ -178,7 +178,7 @@ public class GameID {
             return false;
         }
 
-        return Objects.equals(gameId.getData(), ((GameID) obj).gameId.getData());
+        return ObjectsCompat.equals(gameId.getData(), ((GameID) obj).gameId.getData());
     }
 
     /**

--- a/src/main/java/in/dragonbra/javasteam/types/GlobalID.java
+++ b/src/main/java/in/dragonbra/javasteam/types/GlobalID.java
@@ -1,7 +1,8 @@
 package in.dragonbra.javasteam.types;
 
+import in.dragonbra.javasteam.util.compat.ObjectsCompat;
+
 import java.util.Date;
-import java.util.Objects;
 
 /**
  * Represents a globally unique identifier within the Steam network.
@@ -134,7 +135,7 @@ public class GlobalID {
             return false;
         }
 
-        return Objects.equals(gidBits.getData(), ((GlobalID) obj).gidBits.getData());
+        return ObjectsCompat.equals(gidBits.getData(), ((GlobalID) obj).gidBits.getData());
     }
 
     /**

--- a/src/main/java/in/dragonbra/javasteam/types/SteamID.java
+++ b/src/main/java/in/dragonbra/javasteam/types/SteamID.java
@@ -4,6 +4,7 @@ import in.dragonbra.javasteam.enums.EAccountType;
 import in.dragonbra.javasteam.enums.EUniverse;
 import in.dragonbra.javasteam.util.CollectionUtils;
 import in.dragonbra.javasteam.util.Strings;
+import in.dragonbra.javasteam.util.compat.ObjectsCompat;
 
 import java.util.*;
 import java.util.regex.Matcher;
@@ -554,7 +555,7 @@ public class SteamID {
 
         SteamID sid = (SteamID) obj;
 
-        return Objects.equals(steamID.getData(), sid.steamID.getData());
+        return ObjectsCompat.equals(steamID.getData(), sid.steamID.getData());
     }
 
     /**

--- a/src/main/java/in/dragonbra/javasteam/util/CollectionUtils.java
+++ b/src/main/java/in/dragonbra/javasteam/util/CollectionUtils.java
@@ -1,7 +1,8 @@
 package in.dragonbra.javasteam.util;
 
+import in.dragonbra.javasteam.util.compat.ObjectsCompat;
+
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * @author lngtr
@@ -10,7 +11,7 @@ import java.util.Objects;
 public class CollectionUtils {
     public static <T, E> T getKeyByValue(Map<T, E> map, E value) {
         for (Map.Entry<T, E> entry : map.entrySet()) {
-            if (Objects.equals(value, entry.getValue())) {
+            if (ObjectsCompat.equals(value, entry.getValue())) {
                 return entry.getKey();
             }
         }

--- a/src/main/java/in/dragonbra/javasteam/util/compat/ObjectsCompat.java
+++ b/src/main/java/in/dragonbra/javasteam/util/compat/ObjectsCompat.java
@@ -1,0 +1,11 @@
+package in.dragonbra.javasteam.util.compat;
+
+/**
+ * @author steev
+ * @since 2018-03-21
+ */
+public class ObjectsCompat {
+    public static boolean equals(Object a, Object b) {
+        return (a == b) || (a != null && a.equals(b));
+    }
+}

--- a/src/test/java/in/dragonbra/javasteam/util/compat/ObjectsCompatTest.java
+++ b/src/test/java/in/dragonbra/javasteam/util/compat/ObjectsCompatTest.java
@@ -1,0 +1,27 @@
+package in.dragonbra.javasteam.util.compat;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import in.dragonbra.javasteam.TestBase;
+
+public class ObjectsCompatTest extends TestBase {
+
+    @Test
+    public void testEquals() throws Exception {
+        final String a = "aaa";
+        final String b = "bbb";
+        final String c = null;
+
+        assertFalse(ObjectsCompat.equals(a, b));
+        assertFalse(ObjectsCompat.equals(a, c));
+        assertFalse(ObjectsCompat.equals(c, a));
+
+        assertTrue(ObjectsCompat.equals(a, a));
+        assertTrue(ObjectsCompat.equals(b, b));
+        assertTrue(ObjectsCompat.equals(c, c));
+    }
+
+}


### PR DESCRIPTION
### Description
Android didn't add support for the Objects class until API level 19 (KitKat). This PR simply uses a compat class that does the same thing.

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
