### PR TITLE
Fix assertion when -ea is enabled.

### DIFF
--- a/src/main/java/in/dragonbra/javasteam/steam/CMClient.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/CMClient.java
@@ -151,7 +151,7 @@ public abstract class CMClient {
             try {
                 disconnect();
 
-                assert connection != null;
+                assert connection == null;
 
                 expectDisconnection = false;
 


### PR DESCRIPTION
### Description
When working with Android Studio or have -ea enabled within your ide, we'll crash before we even connect as the assert was backwards. 

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
