### PR TITLE
Tell other signed in clients of persona state changes. 

### DIFF
--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamfriends/SteamFriends.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamfriends/SteamFriends.java
@@ -190,6 +190,7 @@ public class SteamFriends extends ClientMsgHandler {
         ClientMsgProtobuf<CMsgClientChangeStatus.Builder> stateMsg = new ClientMsgProtobuf<>(CMsgClientChangeStatus.class, EMsg.ClientChangeStatus);
 
         stateMsg.getBody().setPersonaState(state.code());
+        stateMsg.getBody().setPersonaSetByUser(true);
 
         client.send(stateMsg);
     }


### PR DESCRIPTION
### Description

While logged into other clients, setting your persona state will not tell other clients of your desired status... This could lead to your status not changing at all.

Setting the value of `true` to `CMsgClientChangeStatus.persona_set_by_user` fixes this issue. 

Note:
Setting Online/Away works, but choosing Invisible does not register for some reason while signed into multiple clients. 
But if javasteam is the only client signed in, it will work. 🤔 

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
