### PR TITLE
appid in GetDepotDecryptionKey is not optional

### DIFF
--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamapps/SteamApps.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamapps/SteamApps.java
@@ -134,18 +134,7 @@ public class SteamApps extends ClientMsgHandler {
      * Results are returned in a {@link DepotKeyCallback} callback.
      *
      * @param depotId The DepotID to request a decryption key for.
-     * @return The Job ID of the request. This can be used to find the appropriate {@link DepotKeyCallback}.
-     */
-    public JobID getDepotDecryptionKey(int depotId) {
-        return getDepotDecryptionKey(depotId, 0);
-    }
-
-    /**
-     * Request the depot decryption key for a specified DepotID.
-     * Results are returned in a {@link DepotKeyCallback} callback.
-     *
-     * @param depotId The DepotID to request a decryption key for.
-     * @param appId   The AppID to request the decryption key for.
+     * @param appId   The AppID parent of the DepotID.
      * @return The Job ID of the request. This can be used to find the appropriate {@link DepotKeyCallback}.
      */
     public JobID getDepotDecryptionKey(int depotId, int appId) {

--- a/src/test/java/in/dragonbra/javasteam/steam/handlers/steamapps/SteamAppsTest.java
+++ b/src/test/java/in/dragonbra/javasteam/steam/handlers/steamapps/SteamAppsTest.java
@@ -49,14 +49,14 @@ public class SteamAppsTest extends HandlerTestBase<SteamApps> {
 
     @Test
     public void getDepotDecryptionKey() {
-        JobID jobID = handler.getDepotDecryptionKey(10);
+        JobID jobID = handler.getDepotDecryptionKey(731, 730);
 
         ClientMsgProtobuf<CMsgClientGetDepotDecryptionKey.Builder> msg = verifySend(EMsg.ClientGetDepotDecryptionKey);
 
         assertEquals(SOURCE_JOB_ID, msg.getSourceJobID());
         assertEquals(SOURCE_JOB_ID, jobID);
-        assertEquals(10, msg.getBody().getDepotId());
-        assertEquals(0, msg.getBody().getAppId());
+        assertEquals(731, msg.getBody().getDepotId());
+        assertEquals(730, msg.getBody().getAppId());
     }
 
     @Test
@@ -162,7 +162,7 @@ public class SteamAppsTest extends HandlerTestBase<SteamApps> {
 
         assertEquals(EResult.OK, callback.getResult());
         assertEquals(440, callback.getAppID());
-        assertArrayEquals(new byte[] {}, callback.getTicket());
+        assertArrayEquals(new byte[]{}, callback.getTicket());
     }
 
     @Test
@@ -175,7 +175,7 @@ public class SteamAppsTest extends HandlerTestBase<SteamApps> {
 
         assertEquals(EResult.OK, callback.getResult());
         assertEquals(1, callback.getDepotID());
-        assertArrayEquals(new byte[] {}, callback.getDepotKey());
+        assertArrayEquals(new byte[]{}, callback.getDepotKey());
     }
 
     @Test
@@ -307,6 +307,6 @@ public class SteamAppsTest extends HandlerTestBase<SteamApps> {
 
         assertEquals(EResult.OK, callback.getResult());
         assertEquals(1, callback.getBetaPasswords().size());
-        assertArrayEquals(new byte[] {(byte) 0xAA, (byte) 0xAA}, callback.getBetaPasswords().get("testname"));
+        assertArrayEquals(new byte[]{(byte) 0xAA, (byte) 0xAA}, callback.getBetaPasswords().get("testname"));
     }
 }


### PR DESCRIPTION
### Description

Fixes #73 

Tests updated too since appID isn't optional. 

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
