### PR TITLE
Add support for setting ClientType state

### DIFF
--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamfriends/SteamFriends.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamfriends/SteamFriends.java
@@ -218,8 +218,7 @@ public class SteamFriends extends ClientMsgHandler {
      */
     public void setPersonaStateFlag(EPersonaStateFlag flag) {
         if (flag.code() < EPersonaStateFlag.ClientTypeWeb.code() || flag.code() > EPersonaStateFlag.ClientTypeVR.code()) {
-            logger.debug("Persona State Flag was not a valid ClientType (" + flag.code() + ").");
-            return;
+            throw new IllegalArgumentException("Persona State Flag was not a valid ClientType");
         }
 
         ClientMsgProtobuf<CMsgClientChangeStatus.Builder> stateMsg = new ClientMsgProtobuf<>(CMsgClientChangeStatus.class, EMsg.ClientChangeStatus);


### PR DESCRIPTION
### Description

Fixes #43 

I swore I tried this not to long ago it wasn't working. But going back at it tonight it was working and verified it on two accounts, along with a friend observing my status. 

Since the new web chat is basically a browser version of the steam app for chat, I think EPersonaStateFlag.ClientTypeWeb is deprecated. I can no longer get it to register. But I'll keep it as a valid client type incase there's some legacy way to enable it until its removed from the enums. 

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
