### PR TITLE
Fix race condition in CMClient.send

### DIFF
--- a/src/main/java/in/dragonbra/javasteam/steam/CMClient.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/CMClient.java
@@ -194,12 +194,16 @@ public abstract class CMClient {
             throw new IllegalArgumentException("A value for 'msg' must be supplied");
         }
 
-        if (sessionID != null) {
-            msg.setSessionID(sessionID);
+        Integer _sessionID = this.sessionID;
+
+        if (_sessionID != null) {
+            msg.setSessionID(_sessionID);
         }
 
-        if (steamID != null) {
-            msg.setSteamID(steamID);
+        SteamID _steamID = this.steamID;
+
+        if (_steamID != null) {
+            msg.setSteamID(_steamID);
         }
 
         logger.debug(String.format("Sent -> EMsg: %s (Proto: %s)", msg.getMsgType(), msg.isProto()));


### PR DESCRIPTION
### Description

Checks off PR 913 in #181 

While I couldn't confirm any race conditions, accessing the variable twice could get sketchy imo. 

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
