### PR TITLE
Fix for NetworkInformationException

### DIFF
--- a/src/main/java/in/dragonbra/javasteam/util/HardwareUtils.java
+++ b/src/main/java/in/dragonbra/javasteam/util/HardwareUtils.java
@@ -33,7 +33,12 @@ public class HardwareUtils {
             SERIAL_NUMBER = getSerialNumberUnix();
         }
 
-        return SERIAL_NUMBER == null ? new byte[0] : SERIAL_NUMBER.getBytes();
+        // if SERIAL_NUMBER still was null
+        if(SERIAL_NUMBER == null) {
+            SERIAL_NUMBER = "JavaSteam-SerialNumber";
+        }
+
+        return SERIAL_NUMBER.getBytes();
     }
 
     private static String getSerialNumberWin() {


### PR DESCRIPTION
### Description

While the parent issue (630) isn't really applicable to JavaSteam, their class actually returns something if all else fails. Javasteam just returns an empty byte array. 

This PR changes getMachineID() to return something, instead of just an empty byte array. 

Fixes: #46 

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
