### PR TITLE
Add ServerRecord.TryCreateSocketServer()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.8'
     implementation 'com.google.protobuf:protobuf-java:3.17.3'
     implementation 'com.squareup.okhttp3:okhttp:3.12.13'
+    implementation 'commons-validator:commons-validator:1.7'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'org.java-websocket:Java-WebSocket:1.5.2'
     testCompile 'com.squareup.okhttp3:mockwebserver:3.12.13'

--- a/src/main/java/in/dragonbra/javasteam/steam/discovery/ServerRecord.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/discovery/ServerRecord.java
@@ -1,6 +1,7 @@
 package in.dragonbra.javasteam.steam.discovery;
 
 import in.dragonbra.javasteam.networking.steam3.ProtocolTypes;
+import in.dragonbra.javasteam.util.NetHelpers;
 
 import java.net.InetSocketAddress;
 import java.util.EnumSet;
@@ -52,6 +53,24 @@ public class ServerRecord {
     }
 
     public static ServerRecord createSocketServer(InetSocketAddress endpoint) {
+        return new ServerRecord(endpoint, EnumSet.of(ProtocolTypes.TCP, ProtocolTypes.UDP));
+    }
+
+    /**
+     * Creates a Socket server given an IP endpoint.
+     *
+     * @param address The IP address and port of the server, as a string.
+     * @return A new [ServerRecord], if the address was able to be parsed. **null** otherwise.
+     */
+    public static ServerRecord tryCreateSocketServer(String address) {
+        InetSocketAddress endpoint;
+
+        endpoint = NetHelpers.tryParseIPEndPoint(address);
+
+        if (endpoint == null) {
+            return null;
+        }
+
         return new ServerRecord(endpoint, EnumSet.of(ProtocolTypes.TCP, ProtocolTypes.UDP));
     }
 

--- a/src/main/java/in/dragonbra/javasteam/steam/webapi/SteamDirectory.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/webapi/SteamDirectory.java
@@ -4,9 +4,9 @@ import in.dragonbra.javasteam.enums.EResult;
 import in.dragonbra.javasteam.steam.discovery.ServerRecord;
 import in.dragonbra.javasteam.steam.steamclient.configuration.SteamConfiguration;
 import in.dragonbra.javasteam.types.KeyValue;
+import in.dragonbra.javasteam.util.NetHelpers;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -65,8 +65,10 @@ public class SteamDirectory {
         List<ServerRecord> records = new ArrayList<>();
 
         for (KeyValue socket : socketList.getChildren()) {
-            String[] split = socket.getValue().split(":");
-            records.add(ServerRecord.createSocketServer(new InetSocketAddress(split[0], Integer.parseInt(split[1]))));
+            ServerRecord record = ServerRecord.tryCreateSocketServer(socket.getValue());
+            if (record != null) {
+                records.add(record);
+            }
         }
 
         for (KeyValue socket : webSocketList.getChildren()) {

--- a/src/main/java/in/dragonbra/javasteam/util/NetHelpers.java
+++ b/src/main/java/in/dragonbra/javasteam/util/NetHelpers.java
@@ -1,6 +1,9 @@
 package in.dragonbra.javasteam.util;
 
+import org.apache.commons.validator.routines.InetAddressValidator;
+
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 
@@ -26,5 +29,28 @@ public class NetHelpers {
     public static int getIPAddress(InetAddress ip) {
         final ByteBuffer buff = ByteBuffer.wrap(ip.getAddress());
         return (int) (buff.getInt() & 0xFFFFFFFFL);
+    }
+
+
+    public static InetSocketAddress tryParseIPEndPoint(String address) {
+        if (address == null) {
+            return null;
+        }
+
+        String[] split = address.split(":");
+
+        if (!InetAddressValidator.getInstance().isValidInet4Address(split[0])) {
+            return null;
+        }
+
+        try {
+            if (split.length > 1) {
+                return new InetSocketAddress(split[0], Integer.parseInt(split[1]));
+            }
+        } catch (IllegalArgumentException exception) {
+            // no-op
+        }
+
+        return null;
     }
 }

--- a/src/test/java/in/dragonbra/javasteam/steam/discovery/ServerRecordTest.java
+++ b/src/test/java/in/dragonbra/javasteam/steam/discovery/ServerRecordTest.java
@@ -4,6 +4,9 @@ import in.dragonbra.javasteam.TestBase;
 import in.dragonbra.javasteam.networking.steam3.ProtocolTypes;
 import org.junit.Test;
 
+import java.net.InetSocketAddress;
+import java.util.EnumSet;
+
 import static org.junit.Assert.*;
 
 /**
@@ -54,5 +57,40 @@ public class ServerRecordTest extends TestBase {
         assertTrue(r.equals(l));
 
         assertEquals(l.hashCode(), r.hashCode());
+    }
+
+    @Test
+    public void canTryCreateSocketServer() {
+        ServerRecord record = ServerRecord.tryCreateSocketServer("127.0.0.1:1234");
+
+        assertNotNull(record);
+        assertEquals(new InetSocketAddress("127.0.0.1", 1234), record.getEndpoint());
+        assertEquals(EnumSet.of(ProtocolTypes.TCP, ProtocolTypes.UDP), record.getProtocolTypes());
+
+        record = ServerRecord.tryCreateSocketServer("192.168.0.1:5678");
+
+        assertNotNull(record);
+        assertEquals(new InetSocketAddress("192.168.0.1", 5678), record.getEndpoint());
+        assertEquals(EnumSet.of(ProtocolTypes.TCP, ProtocolTypes.UDP), record.getProtocolTypes());
+    }
+
+    @Test
+    public void cannotTryCreateSocketServer() {
+        ServerRecord record;
+
+        record = ServerRecord.tryCreateSocketServer("127.0.0.1");
+        assertNull(record);
+
+        record = ServerRecord.tryCreateSocketServer("127.0.0.1:123456789");
+        assertNull(record);
+
+        record = ServerRecord.tryCreateSocketServer("127.0.0.1:-1234");
+        assertNull(record);
+
+        record = ServerRecord.tryCreateSocketServer("127.0.0.1:notanint");
+        assertNull(record);
+
+        record = ServerRecord.tryCreateSocketServer("volvopls.valvesoftware.com:1234");
+        assertNull(record);
     }
 }


### PR DESCRIPTION
### Description
Adds validation for ServerRecords as shown in the newly added tests. Rejects any invalid IPs, invalid ports, or domain names. 

Fixes #17 

Adds dependancy `commons-validator` for ipv4 validation. 

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
