### PR TITLE
SteamConfiguration.getCellID() is not used in login

### DIFF
--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamuser/AnonymousLogOnDetails.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamuser/AnonymousLogOnDetails.java
@@ -8,7 +8,7 @@ import in.dragonbra.javasteam.util.Utils;
  */
 public class AnonymousLogOnDetails {
 
-    private int cellID;
+    private Integer cellID;
 
     private EOSType clientOSType;
 
@@ -24,7 +24,7 @@ public class AnonymousLogOnDetails {
      *
      * @return the CellID.
      */
-    public int getCellID() {
+    public Integer getCellID() {
         return cellID;
     }
 

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamuser/LogOnDetails.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamuser/LogOnDetails.java
@@ -14,7 +14,7 @@ public class LogOnDetails {
 
     private String password = "";
 
-    private int cellID;
+    private Integer cellID;
 
     private Integer loginID;
 
@@ -87,7 +87,7 @@ public class LogOnDetails {
      *
      * @return the CellID.
      */
-    public int getCellID() {
+    public Integer getCellID() {
         return cellID;
     }
 

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamuser/SteamUser.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamuser/SteamUser.java
@@ -163,7 +163,12 @@ public class SteamUser extends ClientMsgHandler {
         logon.getBody().setProtocolVersion(MsgClientLogon.CurrentProtocol);
         logon.getBody().setClientOsType(details.getClientOSType().code());
         logon.getBody().setClientLanguage(details.getClientLanguage());
-        logon.getBody().setCellId(details.getCellID());
+
+        if (details.getCellID() != null) {
+            logon.getBody().setCellId(details.getCellID());
+        } else {
+            logon.getBody().setCellId(client.getConfiguration().getCellID());
+        }
 
         logon.getBody().setSteam2TicketRequest(details.isRequestSteam2Ticket());
 
@@ -229,7 +234,12 @@ public class SteamUser extends ClientMsgHandler {
         logon.getBody().setProtocolVersion(MsgClientLogon.CurrentProtocol);
         logon.getBody().setClientOsType(details.getClientOSType().code());
         logon.getBody().setClientLanguage(details.getClientLanguage());
-        logon.getBody().setCellId(details.getCellID());
+
+        if (details.getCellID() != null) {
+            logon.getBody().setCellId(details.getCellID());
+        } else {
+            logon.getBody().setCellId(client.getConfiguration().getCellID());
+        }
 
         logon.getBody().setMachineId(ByteString.copyFrom(HardwareUtils.getMachineID()));
 


### PR DESCRIPTION
### Description
Fixes #77 

Stems from 690 from SteamKit

> SteamUser.LogOn and LogOnAnonymous accept details object which can have a cellid set, I think it would be a good idea to set it by default to SteamConfiguration.CellID if it's not provided in LogOnDetails.

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
