### PR TITLE
Create obfuscated_private_ip object when LoginID is provided

### DIFF
--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamuser/SteamUser.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamuser/SteamUser.java
@@ -154,7 +154,7 @@ public class SteamUser extends ClientMsgHandler {
             int localIp = NetHelpers.getIPAddress(client.getLocalIP());
             ipAddress.setV4(localIp ^ MsgClientLogon.ObfuscationMask);
 
-            logon.getBody().setObfuscatedPrivateIp(ipAddress);
+            logon.getBody().setObfuscatedPrivateIp(ipAddress.build());
         }
 
         // Legacy field, Steam client still sets it


### PR DESCRIPTION
### Description
Fixes #132 

Successful logins with or without setting a loginID. 

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
