### PR TITLE
Create default MemoryServerListProvider

### DIFF
--- a/src/main/java/in/dragonbra/javasteam/steam/discovery/MemoryServerListProvider.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/discovery/MemoryServerListProvider.java
@@ -1,0 +1,32 @@
+package in.dragonbra.javasteam.steam.discovery;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A server list provider that uses an in-memory list
+ */
+public class MemoryServerListProvider implements IServerListProvider {
+
+    List<ServerRecord> _server = new ArrayList<>();
+
+    /**
+     * Returns the stored server list in memory
+     *
+     * @return List of servers if persisted, otherwise an empty list
+     */
+    @Override
+    public List<ServerRecord> fetchServerList() {
+        return _server;
+    }
+
+    /**
+     * Stores the supplied list of servers in memory
+     *
+     * @param endpoints List of endpoints (servers)
+     */
+    @Override
+    public void updateServerList(List<ServerRecord> endpoints) {
+        _server = endpoints;
+    }
+}

--- a/src/main/java/in/dragonbra/javasteam/steam/steamclient/configuration/SteamConfigurationBuilder.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/steamclient/configuration/SteamConfigurationBuilder.java
@@ -4,7 +4,7 @@ import in.dragonbra.javasteam.enums.EClientPersonaStateFlag;
 import in.dragonbra.javasteam.enums.EUniverse;
 import in.dragonbra.javasteam.networking.steam3.ProtocolTypes;
 import in.dragonbra.javasteam.steam.discovery.IServerListProvider;
-import in.dragonbra.javasteam.steam.discovery.NullServerListProvider;
+import in.dragonbra.javasteam.steam.discovery.MemoryServerListProvider;
 import in.dragonbra.javasteam.steam.webapi.WebAPI;
 import okhttp3.OkHttpClient;
 
@@ -30,7 +30,7 @@ public class SteamConfigurationBuilder implements ISteamConfigurationBuilder {
         state.setDefaultPersonaStateFlags(EnumSet.of(EClientPersonaStateFlag.PlayerName, EClientPersonaStateFlag.Presence,
                 EClientPersonaStateFlag.SourceID, EClientPersonaStateFlag.GameExtraInfo, EClientPersonaStateFlag.LastSeen));
         state.setProtocolTypes(ProtocolTypes.TCP);
-        state.setServerListProvider(new NullServerListProvider());
+        state.setServerListProvider(new MemoryServerListProvider());
         state.setUniverse(EUniverse.Public);
         state.setWebAPIBaseAddress(WebAPI.DEFAULT_BASE_ADDRESS);
         state.setHttpClient(new OkHttpClient());

--- a/src/test/java/in/dragonbra/javasteam/steam/steamclient/configuration/SteamConfigurationTest.java
+++ b/src/test/java/in/dragonbra/javasteam/steam/steamclient/configuration/SteamConfigurationTest.java
@@ -4,7 +4,7 @@ import in.dragonbra.javasteam.enums.EClientPersonaStateFlag;
 import in.dragonbra.javasteam.enums.EUniverse;
 import in.dragonbra.javasteam.networking.steam3.ProtocolTypes;
 import in.dragonbra.javasteam.steam.discovery.IServerListProvider;
-import in.dragonbra.javasteam.steam.discovery.NullServerListProvider;
+import in.dragonbra.javasteam.steam.discovery.MemoryServerListProvider;
 import in.dragonbra.javasteam.steam.discovery.ServerRecord;
 import in.dragonbra.javasteam.util.compat.Consumer;
 import okhttp3.OkHttpClient;
@@ -70,7 +70,7 @@ public class SteamConfigurationTest {
 
     @Test
     public void serverListProviderIsNothingFancy() {
-        assertTrue(defaultConfig.getServerListProvider() instanceof NullServerListProvider);
+        assertTrue(defaultConfig.getServerListProvider() instanceof MemoryServerListProvider);
     }
 
     @Test


### PR DESCRIPTION
### Description

Checks off item 918 in #181 

From SteamKit's PR:
> This is more useful than the null storage which would request it from the api any time it is requested.

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
