### PR TITLE
Write empty values (null and no children) as an object when saving to binary

### DIFF
--- a/src/main/java/in/dragonbra/javasteam/types/KeyValue.java
+++ b/src/main/java/in/dragonbra/javasteam/types/KeyValue.java
@@ -520,7 +520,7 @@ public class KeyValue {
         // Only supported types ATM:
         // 1. KeyValue with children (no value itself)
         // 2. String KeyValue
-        if (!children.isEmpty()) {
+        if (value == null) {
             os.write(Type.NONE.code());
             os.write(name.getBytes(Charset.forName("UTF-8")));
             os.write(0);
@@ -532,11 +532,7 @@ public class KeyValue {
             os.write(Type.STRING.code());
             os.write(name.getBytes(Charset.forName("UTF-8")));
             os.write(0);
-            if (value == null) {
-                os.write("".getBytes(Charset.forName("UTF-8")));
-            } else {
-                os.write(value.getBytes(Charset.forName("UTF-8")));
-            }
+            os.write(value.getBytes(Charset.forName("UTF-8")));
             os.write(0);
         }
     }


### PR DESCRIPTION
### Description

Checks off 937 in #181 

>This will match the behaviour of text saving. And looking at Valve's code, they default to type none, so when serializing it should be saved as an object as well.
> 
>I believe right now deserializing an empty object, and then serializing back into binary would not be roundtrip in Steamkit.

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
