### PR TITLE
SteamMatchmaking - creating, retrieving, listing, joining and leaving lobbies.

### DIFF
--- a/src/main/java/in/dragonbra/javasteam/base/ClientMsgProtobuf.java
+++ b/src/main/java/in/dragonbra/javasteam/base/ClientMsgProtobuf.java
@@ -122,6 +122,13 @@ public class ClientMsgProtobuf<BodyType extends GeneratedMessageV3.Builder<BodyT
         return body;
     }
 
+    /**
+     * Set the body structure of this message
+     */
+    public void setBody(BodyType body) {
+        this.body = body;
+    }
+
     @Override
     public byte[] serialize() {
         ByteArrayOutputStream baos = new ByteArrayOutputStream(0);

--- a/src/main/java/in/dragonbra/javasteam/handlers/ClientMsgHandler.java
+++ b/src/main/java/in/dragonbra/javasteam/handlers/ClientMsgHandler.java
@@ -18,7 +18,7 @@ public abstract class ClientMsgHandler {
     /**
      * Gets whether or not the related {@link SteamClient} should imminently expect the server to close the connection.
      * If this is true when the connection is closed, the {@link DisconnectedCallback}'s
-     * {@link DisconnectedCallback#userInitiated} property will be set to <b>true</b>.
+     * {@link DisconnectedCallback#isUserInitiated()} property will be set to <b>true</b>.
      *
      * @return whether or not the related {@link SteamClient} should imminently expect the server to close the connection.
      */
@@ -29,7 +29,7 @@ public abstract class ClientMsgHandler {
     /**
      * Sets whether or not the related {@link SteamClient} should imminently expect the server to close the connection.
      * If this is true when the connection is closed, the {@link DisconnectedCallback}'s
-     * {@link DisconnectedCallback#userInitiated} property will be set to <b>true</b>.
+     * {@link DisconnectedCallback#isUserInitiated()} property will be set to <b>true</b>.
      *
      * @param expectDisconnection whether or not the related {@link SteamClient} should imminently expect the server to close the connection.
      */

--- a/src/main/java/in/dragonbra/javasteam/steam/CMClient.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/CMClient.java
@@ -46,6 +46,10 @@ public abstract class CMClient {
 
     private SteamConfiguration configuration;
 
+    private InetAddress publicIP;
+
+    private String ipCountryCode;
+
     private boolean isConnected;
 
     private long sessionToken;
@@ -411,6 +415,8 @@ public abstract class CMClient {
             steamID = new SteamID(logonResp.getProtoHeader().getSteamid());
 
             cellID = logonResp.getBody().getCellId();
+            publicIP = NetHelpers.getIPAddress(logonResp.getBody().getPublicIp());
+            ipCountryCode = logonResp.getBody().getIpCountryCode();
 
             // restart heartbeat
             heartBeatFunc.stop();
@@ -494,6 +500,26 @@ public abstract class CMClient {
      */
     public InetSocketAddress getCurrentEndpoint() {
         return connection.getCurrentEndPoint();
+    }
+
+    /**
+     * Gets the public IP address of this client. This value is assigned after a logon attempt has succeeded.
+     * This value will be <strong>null</strong> if the client is logged off of Steam.
+     *
+     * @return The public ip.
+     */
+    public InetAddress getPublicIP() {
+        return publicIP;
+    }
+
+    /**
+     * Gets the country code of our public IP address according to Steam. This value is assigned after a logon attempt has succeeded.
+     * This value will be <strong>null</strong> if the client is logged off of Steam.
+     *
+     * @return The ip country code.
+     */
+    public String getIpCountryCode() {
+        return ipCountryCode;
     }
 
     /**

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamfriends/FriendCache.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamfriends/FriendCache.java
@@ -1,0 +1,206 @@
+package in.dragonbra.javasteam.steam.handlers.steamfriends;
+
+import in.dragonbra.javasteam.enums.EClanRelationship;
+import in.dragonbra.javasteam.enums.EFriendRelationship;
+import in.dragonbra.javasteam.enums.EPersonaState;
+import in.dragonbra.javasteam.enums.EPersonaStateFlag;
+import in.dragonbra.javasteam.types.GameID;
+import in.dragonbra.javasteam.types.SteamID;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.EnumSet;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author lossy
+ * @since 2022-06-12
+ */
+public class FriendCache {
+
+    abstract static class Account {
+
+        private SteamID steamID;
+
+        private String name;
+
+        private byte[] avatarHash;
+
+        public Account() {
+            this.steamID = new SteamID();
+        }
+
+        public SteamID getSteamID() {
+            return steamID;
+        }
+
+        public void setSteamID(SteamID steamID) {
+            this.steamID = steamID;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public byte[] getAvatarHash() {
+            return avatarHash;
+        }
+
+        public void setAvatarHash(byte[] avatarHash) {
+            this.avatarHash = avatarHash;
+        }
+    }
+
+    static class User extends Account {
+
+        private EFriendRelationship relationship;
+
+        private EPersonaState personaState;
+
+        private EnumSet<EPersonaStateFlag> personaStateFlags;
+
+        private int gameAppID;
+
+        private GameID gameID;
+
+        private String gameName;
+
+        public User() {
+            this.gameID = new GameID();
+            this.setPersonaState(EPersonaState.Offline); // JavaSteam edit: Not sure to keep this here.
+        }
+
+        public EFriendRelationship getRelationship() {
+            return relationship;
+        }
+
+        public void setRelationship(EFriendRelationship relationship) {
+            this.relationship = relationship;
+        }
+
+        public EPersonaState getPersonaState() {
+            return personaState;
+        }
+
+        public void setPersonaState(EPersonaState personaState) {
+            this.personaState = personaState;
+        }
+
+        public EnumSet<EPersonaStateFlag> getPersonaStateFlags() {
+            return personaStateFlags;
+        }
+
+        public void setPersonaStateFlags(EnumSet<EPersonaStateFlag> personaStateFlags) {
+            this.personaStateFlags = personaStateFlags;
+        }
+
+        public int getGameAppID() {
+            return gameAppID;
+        }
+
+        public void setGameAppID(int gameAppID) {
+            this.gameAppID = gameAppID;
+        }
+
+        public GameID getGameID() {
+            return gameID;
+        }
+
+        public void setGameID(GameID gameID) {
+            this.gameID = gameID;
+        }
+
+        public String getGameName() {
+            return gameName;
+        }
+
+        public void setGameName(String gameName) {
+            this.gameName = gameName;
+        }
+    }
+
+    static class Clan extends Account {
+
+        public Clan() {
+        }
+
+        private EClanRelationship relationship;
+
+        public EClanRelationship getRelationship() {
+            return relationship;
+        }
+
+        public void setRelationship(EClanRelationship relationship) {
+            this.relationship = relationship;
+        }
+    }
+
+    static class AccountList<T extends Account> extends ConcurrentHashMap<SteamID, T> {
+
+        public T getAccount(SteamID steamId, Class<? extends T> cls) {
+            T account;
+
+            try {
+                account = cls.getConstructor().newInstance();
+            } catch (InstantiationException | IllegalAccessException |
+                     InvocationTargetException | NoSuchMethodException e) {
+                throw new RuntimeException(e);
+            }
+
+            account.setSteamID(steamId);
+
+            // Janky java 7 hack for computeIfAbsent.
+            T v = this.get(steamId);
+            if (v == null) {
+                v = (v = this.putIfAbsent(steamId, account)) == null ? account : v;
+            }
+            return v;
+        }
+    }
+
+    static class AccountCache {
+        private final User localUser;
+
+        private final AccountList<User> users;
+
+        private final AccountList<Clan> clans;
+
+        public AccountCache() {
+            localUser = new User();
+
+            users = new AccountList<>();
+            clans = new AccountList<>();
+        }
+
+        public User getUser(SteamID steamID) {
+            if (isLocalUser(steamID)) {
+                return localUser;
+            } else {
+                return users.getAccount(steamID, User.class);
+            }
+        }
+
+        public Clan getClan(SteamID steamID) {
+            return clans.getAccount(steamID, Clan.class);
+        }
+
+        public User getLocalUser() {
+            return localUser;
+        }
+
+        public AccountList<User> getUsers() {
+            return users;
+        }
+
+        public AccountList<Clan> getClans() {
+            return clans;
+        }
+
+        public boolean isLocalUser(SteamID steamID) {
+            return localUser.getSteamID() == steamID;
+        }
+    }
+}

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steammatchmaking/Lobby.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steammatchmaking/Lobby.java
@@ -1,0 +1,525 @@
+package in.dragonbra.javasteam.steam.handlers.steammatchmaking;
+
+import in.dragonbra.javasteam.enums.ELobbyComparison;
+import in.dragonbra.javasteam.enums.ELobbyDistanceFilter;
+import in.dragonbra.javasteam.enums.ELobbyFilterType;
+import in.dragonbra.javasteam.enums.ELobbyType;
+import in.dragonbra.javasteam.protobufs.steamclient.SteammessagesClientserverMms.CMsgClientMMSGetLobbyList;
+import in.dragonbra.javasteam.types.KeyValue;
+import in.dragonbra.javasteam.types.SteamID;
+import in.dragonbra.javasteam.util.stream.MemoryStream;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents a Steam lobby.
+ *
+ * @author lossy
+ * @since 2022-06-21
+ */
+public class Lobby {
+
+    /**
+     * The lobby filter base class.
+     */
+    abstract class Filter {
+
+        /**
+         * The type of filter.
+         */
+        private ELobbyFilterType filterType;
+
+        /**
+         * The metadata key this filter pertains to. Under certain circumstances e.g. a distance
+         * filter, this will be an empty string.
+         */
+        private String key;
+
+        /**
+         * The comparison method used by this filter.
+         */
+        private ELobbyComparison comparison;
+
+        /**
+         * Base constructor for all filter sub-classes.
+         *
+         * @param filterType The type of filter.
+         * @param key        The metadata key this filter pertains to.
+         * @param comparison The comparison method used by this filter.
+         */
+        public Filter(ELobbyFilterType filterType, String key, ELobbyComparison comparison) {
+            this.filterType = filterType;
+            this.key = key;
+            this.comparison = comparison;
+        }
+
+        /**
+         * Serializes the filter into a representation used internally by SteamMatchmaking.
+         * <p>
+         * Note: Will need to be built to be anything meaningful 'serialize().build();'
+         *
+         * @return A protobuf serializable representation of this filter.
+         */
+        public CMsgClientMMSGetLobbyList.Filter.Builder serialize() {
+            CMsgClientMMSGetLobbyList.Filter.Builder filter = CMsgClientMMSGetLobbyList.Filter.newBuilder();
+            filter.setFilterType(filterType.code());
+            filter.setKey(key);
+            filter.setComparision(comparison.code());
+
+            return filter;
+        }
+
+        public ELobbyFilterType getFilterType() {
+            return filterType;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public ELobbyComparison getComparison() {
+            return comparison;
+        }
+    }
+
+    /**
+     * Can be used to filter lobbies geographically (based on IP according to Steam's IP database).
+     */
+    public class DistanceFilter extends Filter {
+
+        /**
+         * Steam distance filter value.
+         */
+        private ELobbyDistanceFilter value;
+
+
+        /**
+         * Initializes a new instance of the {@link DistanceFilter} class.
+         *
+         * @param value Steam distance filter value
+         */
+        public DistanceFilter(ELobbyDistanceFilter value) {
+            super(ELobbyFilterType.Distance, "", ELobbyComparison.Equal);
+
+            this.value = value;
+        }
+
+        /**
+         * Serializes the distance filter into a representation used internally by SteamMatchmaking.
+         *
+         * @return A protobuf serializable representation of this filter.
+         */
+        @Override
+        public CMsgClientMMSGetLobbyList.Filter.Builder serialize() {
+            CMsgClientMMSGetLobbyList.Filter.Builder filter = super.serialize();
+            filter.setValue(String.valueOf(value.code()));
+
+            return filter;
+        }
+
+        public ELobbyDistanceFilter getValue() {
+            return value;
+        }
+    }
+
+    /**
+     * Can be used to filter lobbies with a metadata value closest to the specified value. Multiple
+     * near filters can be specified, with former filters taking precedence over latter filters.
+     */
+    public class NearValueFilter extends Filter {
+
+        /**
+         * Integer value that lobbies' metadata value should be close to.
+         */
+        private int value;
+
+        /**
+         * Initializes a new instance of the {@link  NearValueFilter}
+         *
+         * @param key   The metadata key this filter pertains to.
+         * @param value Integer value to compare against.
+         */
+        public NearValueFilter(String key, int value) {
+            super(ELobbyFilterType.NearValue, key, ELobbyComparison.Equal);
+
+            this.value = value;
+        }
+
+        /**
+         * Serializes the slots available filter into a representation used internally by SteamMatchmaking.
+         *
+         * @return A protobuf serializable representation of this filter.
+         */
+        @Override
+        public CMsgClientMMSGetLobbyList.Filter.Builder serialize() {
+            CMsgClientMMSGetLobbyList.Filter.Builder filter = super.serialize();
+            filter.setValue(String.valueOf(value));
+
+            return filter;
+        }
+
+        public int getValue() {
+            return value;
+        }
+    }
+
+    /**
+     * Can be used to filter lobbies by comparing an integer against a value in each lobby's metadata.
+     */
+    public class NumericalFilter extends Filter {
+
+        /**
+         * Integer value to compare against.
+         */
+        private int value;
+
+        /**
+         * Initializes a new instance of the {@link NumericalFilter} class.
+         *
+         * @param key        The metadata key this filter pertains to.
+         * @param comparison The comparison method used by this filter.
+         * @param value      Integer value to compare against.
+         */
+        public NumericalFilter(String key, ELobbyComparison comparison, int value) {
+            super(ELobbyFilterType.Numerical, key, comparison);
+
+            this.value = value;
+        }
+
+        /**
+         * Serializes the numerical filter into a representation used internally by SteamMatchmaking.
+         *
+         * @return A protobuf serializable representation of this filter.
+         */
+        @Override
+        public CMsgClientMMSGetLobbyList.Filter.Builder serialize() {
+            CMsgClientMMSGetLobbyList.Filter.Builder filter = super.serialize();
+            filter.setValue(String.valueOf(value));
+
+            return filter;
+        }
+
+        public int getValue() {
+            return value;
+        }
+    }
+
+    /**
+     * Can be used to filter lobbies by minimum number of slots available.
+     */
+    public class SlotsAvailableFilter extends Filter {
+
+        /**
+         * Minumum number of slots available in the lobby.
+         */
+        private int slotsAvailable;
+
+        /**
+         * Initializes a new instance of the {@link  SlotsAvailableFilter} class.
+         *
+         * @param slotsAvailable Integer value to compare against.
+         */
+        public SlotsAvailableFilter(int slotsAvailable) {
+            super(ELobbyFilterType.SlotsAvailable, "", ELobbyComparison.Equal);
+
+            this.slotsAvailable = slotsAvailable;
+        }
+
+
+        /**
+         * Serializes the slots available filter into a representation used internally by SteamMatchmaking.
+         *
+         * @return A protobuf serializable representation of this filter.
+         */
+        @Override
+        public CMsgClientMMSGetLobbyList.Filter.Builder serialize() {
+            CMsgClientMMSGetLobbyList.Filter.Builder filter = super.serialize();
+            filter.setValue(String.valueOf(slotsAvailable));
+
+            return filter;
+        }
+
+        public int getSlotsAvailable() {
+            return slotsAvailable;
+        }
+    }
+
+    /**
+     * Can be used to filter lobbies by comparing a string against a value in each lobby's metadata.
+     */
+    public class StringFilter extends Filter {
+
+        /**
+         * String value to compare against.
+         */
+        private String value;
+
+        /**
+         * Initializes a new instance of the {@link  StringFilter} class.
+         *
+         * @param key        The metadata key this filter pertains to.
+         * @param comparison The comparison method used by this filter.
+         * @param value      String value to compare against.
+         */
+        private StringFilter(String key, ELobbyComparison comparison, String value) {
+            super(ELobbyFilterType.String, key, comparison);
+
+            this.value = value;
+        }
+
+        /**
+         * Serializes the string filter into a representation used internally by SteamMatchmaking.
+         *
+         * @return A protobuf serializable representation of this filter.
+         */
+        @Override
+        public CMsgClientMMSGetLobbyList.Filter.Builder serialize() {
+            CMsgClientMMSGetLobbyList.Filter.Builder filter = super.serialize();
+            filter.setValue(value);
+
+            return filter;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+
+    /**
+     * Represents a Steam user within a lobby.
+     */
+    public static class Member {
+
+        /**
+         * SteamID of the lobby member.
+         */
+        private SteamID steamID;
+
+        /**
+         * Steam persona of the lobby member.
+         */
+        private String personaName;
+
+        /**
+         * Metadata attached to the lobby member.
+         */
+        public HashMap<String, String> metadata;
+
+        public Member(long steamID, String personaName, HashMap<String, String> metadata) {
+            this.steamID = new SteamID(steamID);
+            this.personaName = personaName;
+            this.metadata = metadata;
+        }
+
+        public Member(SteamID steamID, String personaName, HashMap<String, String> metadata) {
+            this.steamID = steamID;
+            this.personaName = personaName;
+            this.metadata = metadata;
+        }
+
+        /**
+         * Checks to see if this lobby member is equal to another. Only the SteamID of the lobby member is taken into account.
+         *
+         * @param obj ""
+         * @return true, if obj is {@link  Member} with a matching SteamID. Otherwise, false.
+         */
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof Member) {
+                return steamID.equals(((Member) obj).steamID);
+            }
+
+            return false;
+        }
+
+        /**
+         * Hash code of the lobby member. Only the SteamID of the lobby member is taken into account.
+         *
+         * @return The hash code of this lobby member.
+         */
+        @Override
+        public int hashCode() {
+            return steamID.hashCode();
+        }
+
+        public SteamID getSteamID() {
+            return steamID;
+        }
+
+        public String getPersonaName() {
+            return personaName;
+        }
+    }
+
+    /**
+     * SteamID of the lobby.
+     */
+    private SteamID steamID;
+
+    /**
+     * The type of the lobby.
+     */
+    private ELobbyType lobbyType;
+
+    /**
+     * The lobby's flags.
+     */
+    private int lobbyFlags;
+
+    /**
+     * The SteamID of the lobby's owner. Please keep in mind that Steam does not provide lobby
+     * owner details for lobbies returned in a lobby list. As such, lobbies that have been
+     * obtained/updated as a result of calling {@link  SteamMatchmaking#getLobbyList}
+     * may have a null (or non-null but state) owner.
+     */
+    private SteamID ownerSteamID;
+
+    /**
+     * The metadata of the lobby; string key-value pairs.
+     */
+    private HashMap<String, String> metadata;
+
+    /**
+     * The maximum number of members that can occupy the lobby.
+     */
+    private int maxMembers;
+
+    /**
+     * The number of members that are currently occupying the lobby.
+     */
+    private int numMembers;
+
+    /**
+     * The number of members that are currently occupying the lobby.
+     */
+    private List<Member> members;
+
+    /**
+     * The distance of the lobby.
+     */
+    private Float distance;
+
+    /**
+     * The weight of the lobby.
+     */
+    private Long weight;
+
+    public Lobby(SteamID steamID, ELobbyType lobbyType, int lobbyFlags, SteamID ownerSteamID,
+                 HashMap<String, String> metadata, int maxMembers, int numMembers, List<Member> members,
+                 Float distance, Long weight) {
+
+        this.steamID = steamID;
+        this.lobbyType = lobbyType;
+        this.lobbyFlags = lobbyFlags;
+        this.ownerSteamID = ownerSteamID;
+
+        if (metadata != null) {
+            this.metadata = metadata;
+        } else {
+            this.metadata = new HashMap<>();
+        }
+
+        this.maxMembers = maxMembers;
+        this.numMembers = numMembers;
+
+        if (members != null) {
+            this.members = members;
+        } else {
+            this.members = new ArrayList<>();
+        }
+
+        this.distance = distance;
+        this.weight = weight;
+    }
+
+    static byte[] encodeMetadata(HashMap<String, String> metadata) {
+        KeyValue keyValue = new KeyValue("");
+
+        if (metadata != null) {
+            for (Map.Entry<String, String> data : metadata.entrySet()) {
+                keyValue.set(data.getKey(), new KeyValue(null, data.getValue()));
+            }
+        }
+
+        MemoryStream ms = new MemoryStream();
+        try {
+            keyValue.saveToStream(ms.asOutputStream(), true);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return ms.toByteArray();
+    }
+
+    static HashMap<String, String> decodeMetadata(byte[] buffer) {
+        if (buffer == null || buffer.length == 0) {
+            return new HashMap<>();
+        }
+
+        KeyValue keyValue = new KeyValue();
+
+        try (MemoryStream ms = new MemoryStream((buffer))) {
+            if (!keyValue.tryReadAsBinary(ms)) {
+                throw new NumberFormatException("Lobby metadata is of an unexpected format");
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+
+        HashMap<String, String> metadata = new HashMap<>();
+        for (KeyValue value : keyValue.getChildren()) {
+            if (value.getName() == null || value.getValue() == null) {
+                continue;
+            }
+
+            metadata.put(value.getName(), value.getValue());
+        }
+
+        return metadata;
+    }
+
+    public SteamID getSteamID() {
+        return steamID;
+    }
+
+    public ELobbyType getLobbyType() {
+        return lobbyType;
+    }
+
+    public int getLobbyFlags() {
+        return lobbyFlags;
+    }
+
+    public SteamID getOwnerSteamID() {
+        return ownerSteamID;
+    }
+
+    public HashMap<String, String> getMetadata() {
+        return metadata;
+    }
+
+    public int getMaxMembers() {
+        return maxMembers;
+    }
+
+    public int getNumMembers() {
+        return numMembers;
+    }
+
+    public List<Member> getMembers() {
+        return members;
+    }
+
+    public float getDistance() {
+        return distance;
+    }
+
+    public long getWeight() {
+        return weight;
+    }
+}

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steammatchmaking/LobbyCache.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steammatchmaking/LobbyCache.java
@@ -1,0 +1,157 @@
+package in.dragonbra.javasteam.steam.handlers.steammatchmaking;
+
+import in.dragonbra.javasteam.types.SteamID;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * @author lossy
+ * @since 2022-06-21
+ */
+public class LobbyCache {
+
+    private ConcurrentMap<Integer, ConcurrentHashMap<SteamID, Lobby>> lobbies = new ConcurrentHashMap<>();
+
+    public Lobby getLobby(int appId, SteamID lobbySteamId) {
+        return getAppLobbies(appId).get(lobbySteamId); // getOrDefault jdk 8
+    }
+
+    public Lobby getLobby(int appId, long lobbySteamId) {
+        return getAppLobbies(appId).get(new SteamID(lobbySteamId)); // getOrDefault jdk 8
+    }
+
+    public Lobby cacheLobby(int appId, Lobby lobby) {
+        return getAppLobbies(appId).put(lobby.getSteamID(), lobby);
+    }
+
+    public Lobby.Member addLobbyMember(int appId, Lobby lobby, long memberId, String personaName) {
+        return addLobbyMember(appId, lobby, new SteamID(memberId), personaName);
+    }
+
+    public Lobby.Member addLobbyMember(int appId, Lobby lobby, SteamID memberId, String personaName) {
+        Lobby.Member existingMember = null;
+
+        for (Lobby.Member member : lobby.getMembers()) {
+            if (member.getSteamID().equals(memberId)) {
+                existingMember = member;
+                break;
+            }
+        }
+
+        if (existingMember != null) {
+            // Already in lobby.
+            return null;
+        }
+
+        Lobby.Member addedMember = new Lobby.Member(memberId, personaName, null);
+
+        List<Lobby.Member> members = new ArrayList<>(lobby.getMembers().size() + 1);
+        members.addAll(lobby.getMembers());
+        members.add(addedMember);
+
+        updateLobbyMembers(appId, lobby, members);
+
+        return addedMember;
+    }
+
+    public Lobby.Member removeLobbyMember(int appId, Lobby lobby, long memberId) {
+        return removeLobbyMember(appId, lobby, new SteamID(memberId));
+    }
+
+    public Lobby.Member removeLobbyMember(int appId, Lobby lobby, SteamID memberId) {
+        Lobby.Member removedMember = null;
+
+        for (Lobby.Member member : lobby.getMembers()) {
+            if (member.getSteamID().equals(memberId)) {
+                removedMember = member;
+                break;
+            }
+        }
+
+        if (removedMember == null) {
+            return null;
+        }
+
+        List<Lobby.Member> members = new ArrayList<>();
+
+        // I think this is correct for jdk 7 style
+        for (Lobby.Member member : lobby.getMembers()) {
+            if (!member.equals(removedMember)) {
+                members.add(member);
+            }
+        }
+
+        if (members.size() > 0) {
+            updateLobbyMembers(appId, lobby, members);
+        } else {
+            // Steam deletes lobbies that contain no members.
+            deleteLobby(appId, lobby.getSteamID());
+        }
+
+        return removedMember;
+    }
+
+    public void clearLobbyMembers(int appId, long lobbySteamId) {
+        clearLobbyMembers(appId, new SteamID(lobbySteamId));
+    }
+
+    public void clearLobbyMembers(int appId, SteamID lobbySteamId) {
+        Lobby lobby = getLobby(appId, lobbySteamId);
+
+        if (lobby != null) {
+            updateLobbyMembers(appId, lobby, null, null);
+        }
+    }
+
+    public void updateLobbyOwner(int appId, long lobbySteamId, long ownerSteamId) {
+        updateLobbyOwner(appId, new SteamID(lobbySteamId), new SteamID(ownerSteamId));
+    }
+
+    public void updateLobbyOwner(int appId, SteamID lobbySteamId, SteamID ownerSteamId) {
+        Lobby lobby = getLobby(appId, lobbySteamId);
+
+        if (lobby != null) {
+            updateLobbyMembers(appId, lobby, ownerSteamId, lobby.getMembers());
+        }
+    }
+
+    public void updateLobbyMembers(int appId, Lobby lobby, List<Lobby.Member> members) {
+        updateLobbyMembers(appId, lobby, lobby.getOwnerSteamID(), members);
+    }
+
+    public void clear() {
+        lobbies.clear();
+    }
+
+    void updateLobbyMembers(int appId, Lobby lobby, SteamID owner, List<Lobby.Member> members) {
+        cacheLobby(appId, new Lobby(
+                lobby.getSteamID(),
+                lobby.getLobbyType(),
+                lobby.getLobbyFlags(),
+                owner,
+                lobby.getMetadata(),
+                lobby.getMaxMembers(),
+                lobby.getNumMembers(),
+                members,
+                lobby.getDistance(),
+                lobby.getWeight()
+        ));
+    }
+
+    public ConcurrentMap<SteamID, Lobby> getAppLobbies(int appId) {
+        return lobbies.putIfAbsent(appId, new ConcurrentHashMap<SteamID, Lobby>());
+    }
+
+    public Lobby deleteLobby(int appId, SteamID lobbySteamId) {
+        ConcurrentHashMap<SteamID, Lobby> appLobbies = lobbies.get(appId);
+
+        if (appLobbies == null) {
+            return null;
+        }
+
+        return appLobbies.remove(lobbySteamId);
+    }
+}

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steammatchmaking/SteamMatchmaking.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steammatchmaking/SteamMatchmaking.java
@@ -1,0 +1,729 @@
+package in.dragonbra.javasteam.steam.handlers.steammatchmaking;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.GeneratedMessageV3;
+import in.dragonbra.javasteam.base.ClientMsgProtobuf;
+import in.dragonbra.javasteam.base.IPacketMsg;
+import in.dragonbra.javasteam.enums.EChatRoomEnterResponse;
+import in.dragonbra.javasteam.enums.ELobbyType;
+import in.dragonbra.javasteam.enums.EMsg;
+import in.dragonbra.javasteam.enums.EResult;
+import in.dragonbra.javasteam.handlers.ClientMsgHandler;
+import in.dragonbra.javasteam.protobufs.steamclient.SteammessagesClientserverMms.*;
+import in.dragonbra.javasteam.steam.handlers.steamfriends.SteamFriends;
+import in.dragonbra.javasteam.steam.handlers.steammatchmaking.callback.*;
+import in.dragonbra.javasteam.types.JobID;
+import in.dragonbra.javasteam.types.SteamID;
+import in.dragonbra.javasteam.util.NetHelpers;
+import in.dragonbra.javasteam.util.compat.Consumer;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author lossy
+ * @since 2022-06-21
+ */
+public class SteamMatchmaking extends ClientMsgHandler {
+
+    private Map<EMsg, Consumer<IPacketMsg>> dispatchMap;
+
+    private final ConcurrentHashMap<JobID, GeneratedMessageV3> lobbyManipulationRequests = new ConcurrentHashMap<>();
+
+    private final LobbyCache lobbyCache = new LobbyCache();
+
+    public SteamMatchmaking() {
+        dispatchMap = new HashMap<>();
+
+        dispatchMap.put(EMsg.ClientMMSCreateLobbyResponse, new Consumer<IPacketMsg>() {
+            @Override
+            public void accept(IPacketMsg packetMsg) {
+                handleCreateLobbyResponse(packetMsg);
+            }
+        });
+        dispatchMap.put(EMsg.ClientMMSSetLobbyDataResponse, new Consumer<IPacketMsg>() {
+            @Override
+            public void accept(IPacketMsg packetMsg) {
+                handleSetLobbyDataResponse(packetMsg);
+            }
+        });
+        dispatchMap.put(EMsg.ClientMMSSetLobbyOwnerResponse, new Consumer<IPacketMsg>() {
+            @Override
+            public void accept(IPacketMsg packetMsg) {
+                handleSetLobbyOwnerResponse(packetMsg);
+            }
+        });
+        dispatchMap.put(EMsg.ClientMMSLobbyData, new Consumer<IPacketMsg>() {
+            @Override
+            public void accept(IPacketMsg packetMsg) {
+                handleLobbyData(packetMsg);
+            }
+        });
+        dispatchMap.put(EMsg.ClientMMSGetLobbyListResponse, new Consumer<IPacketMsg>() {
+            @Override
+            public void accept(IPacketMsg packetMsg) {
+                handleGetLobbyListResponse(packetMsg);
+            }
+        });
+        dispatchMap.put(EMsg.ClientMMSJoinLobbyResponse, new Consumer<IPacketMsg>() {
+            @Override
+            public void accept(IPacketMsg packetMsg) {
+                handleJoinLobbyResponse(packetMsg);
+            }
+        });
+        dispatchMap.put(EMsg.ClientMMSLeaveLobbyResponse, new Consumer<IPacketMsg>() {
+            @Override
+            public void accept(IPacketMsg packetMsg) {
+                handleLeaveLobbyResponse(packetMsg);
+            }
+        });
+        dispatchMap.put(EMsg.ClientMMSUserJoinedLobby, new Consumer<IPacketMsg>() {
+            @Override
+            public void accept(IPacketMsg packetMsg) {
+                handleUserJoinedLobby(packetMsg);
+            }
+        });
+        dispatchMap.put(EMsg.ClientMMSUserLeftLobby, new Consumer<IPacketMsg>() {
+            @Override
+            public void accept(IPacketMsg packetMsg) {
+                handleUserLeftLobby(packetMsg);
+            }
+        });
+
+        dispatchMap = Collections.unmodifiableMap(dispatchMap);
+    }
+
+    /**
+     * Sends a request to create a new lobby.
+     * <p>
+     * Returns nothing if the request could not be submitted i.e. not yet logged in. Otherwise, an {@link CreateLobbyCallback}.
+     *
+     * @param appId      ID of the app the lobby will belong to.
+     * @param lobbyType  The new lobby type.
+     * @param maxMembers The new maximum number of members that may occupy the lobby.
+     * @param lobbyFlags The new lobby flags. Defaults to 0.
+     * @param metadata   The new metadata for the lobby. Defaults to <strong>null</strong> (treated as an empty dictionary).
+     */
+    public void createLobby(int appId, ELobbyType lobbyType, int maxMembers, Integer lobbyFlags, HashMap<String, String> metadata) {
+        if (client.getCellID() == null) {
+            return;
+        }
+
+        String personaName = client.getHandler(SteamFriends.class).getPersonaName();
+
+        ClientMsgProtobuf<CMsgClientMMSCreateLobby.Builder> createLobby =
+                new ClientMsgProtobuf<>(CMsgClientMMSCreateLobby.class, EMsg.ClientMMSCreateLobby);
+
+        CMsgClientMMSCreateLobby.Builder body = createLobby
+                .getBody()
+                .setAppId(appId)
+                .setLobbyType(lobbyType.code())
+                .setMaxMembers(maxMembers)
+                .setLobbyFlags(lobbyFlags != null ? lobbyFlags : 0)
+                .setMetadata(ByteString.copyFrom(Lobby.encodeMetadata(metadata)))
+                .setCellId(client.getCellID())
+                .setPublicIp(NetHelpers.getMsgIPAddress(client.getPublicIP()))
+                .setPersonaNameOwner(personaName);
+
+        createLobby.setBody(body);
+        createLobby.getProtoHeader().setJobidSource(client.getNextJobID().getValue());
+
+        send(createLobby, appId);
+
+        lobbyManipulationRequests.put(createLobby.getSourceJobID(), createLobby.getBody().build());
+    }
+
+    /**
+     * Sends a request to update a lobby.
+     * <p>
+     * Returns {@link SetLobbyDataCallback}.
+     *
+     * @param appId        ID of app the lobby belongs to.
+     * @param lobbySteamId The SteamID of the lobby that should be updated.
+     * @param lobbyType    The new lobby type.
+     * @param maxMembers   The new maximum number of members that may occupy the lobby.
+     * @param lobbyFlags   The new lobby flags. Defaults to 0.
+     * @param metadata     The new metadata for the lobby. Defaults to <strong>null</strong> (treated as an empty dictionary).
+     */
+    public void setLobbyData(int appId, SteamID lobbySteamId, ELobbyType lobbyType, int maxMembers, Integer lobbyFlags, HashMap<String, String> metadata) {
+        ClientMsgProtobuf<CMsgClientMMSSetLobbyData.Builder> setLobbyData =
+                new ClientMsgProtobuf<>(CMsgClientMMSSetLobbyData.class, EMsg.ClientMMSSetLobbyData);
+
+        CMsgClientMMSSetLobbyData.Builder body = setLobbyData
+                .getBody()
+                .setAppId(appId)
+                .setSteamIdLobby(lobbySteamId.convertToUInt64())
+                .setSteamIdMember(0L)
+                .setLobbyType(lobbyType.code())
+                .setMaxMembers(maxMembers)
+                .setLobbyFlags((lobbyFlags != null) ? lobbyFlags : 0)
+                .setMetadata(ByteString.copyFrom(Lobby.encodeMetadata(metadata)));
+
+        setLobbyData.setBody(body);
+        setLobbyData.setSourceJobID(client.getNextJobID());
+
+        send(setLobbyData, appId);
+
+        lobbyManipulationRequests.put(setLobbyData.getSourceJobID(), setLobbyData.getBody().build());
+    }
+
+    /**
+     * Sends a request to update the current user's lobby metadata.
+     * <p>
+     * Returns nothing if the request could not be submitted i.e. not yet logged in.
+     * Otherwise, an {@link SetLobbyDataCallback}
+     *
+     * @param appId        ID of app the lobby belongs to.
+     * @param lobbySteamId The SteamID of the lobby that should be updated.
+     * @param metadata     The new metadata for the lobby.
+     */
+    public void setLobbyMemberData(int appId, SteamID lobbySteamId, HashMap<String, String> metadata) {
+        if (client.getSteamID() == null) {
+            return;
+        }
+
+        ClientMsgProtobuf<CMsgClientMMSSetLobbyData.Builder> setLobbyData =
+                new ClientMsgProtobuf<>(CMsgClientMMSSetLobbyData.class, EMsg.ClientMMSSetLobbyData);
+
+        CMsgClientMMSSetLobbyData.Builder body = setLobbyData
+                .getBody()
+                .setAppId(appId)
+                .setSteamIdLobby(lobbySteamId.convertToUInt64())
+                .setSteamIdMember(client.getSteamID().convertToUInt64())
+                .setMetadata(ByteString.copyFrom(Lobby.encodeMetadata(metadata)));
+
+        setLobbyData.setBody(body);
+        setLobbyData.setSourceJobID(client.getNextJobID());
+
+        send(setLobbyData, appId);
+
+        lobbyManipulationRequests.put(setLobbyData.getSourceJobID(), setLobbyData.getBody().build());
+    }
+
+    /**
+     * Sends a request to update the owner of a lobby.
+     * <p>
+     * Returns an {@link  SetLobbyOwnerCallback}
+     *
+     * @param appId        ID of app the lobby belongs to.
+     * @param lobbySteamId The SteamID of the lobby that should have its owner updated.
+     * @param newOwner     The SteamID of the new owner.
+     */
+    public void setLobbyOwner(int appId, SteamID lobbySteamId, SteamID newOwner) {
+        ClientMsgProtobuf<CMsgClientMMSSetLobbyOwner.Builder> setLobbyOwner =
+                new ClientMsgProtobuf<>(CMsgClientMMSSetLobbyOwner.class, EMsg.ClientMMSSetLobbyOwner);
+
+        CMsgClientMMSSetLobbyOwner.Builder body = setLobbyOwner
+                .getBody()
+                .setAppId(appId)
+                .setSteamIdLobby(lobbySteamId.convertToUInt64())
+                .setSteamIdNewOwner(newOwner.convertToUInt64());
+
+        setLobbyOwner.setBody(body);
+        setLobbyOwner.setSourceJobID(client.getNextJobID());
+
+        send(setLobbyOwner, appId);
+
+        lobbyManipulationRequests.put(setLobbyOwner.getSourceJobID(), setLobbyOwner.getBody().build());
+    }
+
+    /**
+     * Sends a request to obtains a list of lobbies matching the specified criteria.
+     * <p>
+     * Returns nothing if the request could not be submitted i.e. not yet logged in.
+     * Otherwise, an {@link  GetLobbyListCallback}.
+     *
+     * @param appId      The ID of app for which we're requesting a list of lobbies.
+     * @param filters    An optional list of filters.
+     * @param maxLobbies An optional maximum number of lobbies that will be returned.
+     */
+    public void getLobbyList(int appId, List<Lobby.Filter> filters, Integer maxLobbies) {
+        if (client.getCellID() == null) {
+            return;
+        }
+
+        ClientMsgProtobuf<CMsgClientMMSGetLobbyList.Builder> getLobbies =
+                new ClientMsgProtobuf<>(CMsgClientMMSGetLobbyList.class, EMsg.ClientMMSGetLobbyList);
+
+        int maxLobbiesReq = -1;
+        if (maxLobbies != null) {
+            maxLobbiesReq = maxLobbies;
+        }
+
+        CMsgClientMMSGetLobbyList.Builder body = getLobbies
+                .getBody()
+                .setAppId(appId)
+                .setCellId(client.getCellID())
+                .setPublicIp(NetHelpers.getMsgIPAddress(client.getPublicIP()))
+                .setNumLobbiesRequested(maxLobbiesReq);
+
+        getLobbies.setBody(body);
+        getLobbies.setSourceJobID(client.getNextJobID());
+
+        if (filters != null) {
+            for (Lobby.Filter filter : filters) {
+                getLobbies.getBody().addFilters(filter.serialize().build());
+
+            }
+        }
+
+        send(getLobbies, appId);
+    }
+
+    /**
+     * Sends a request to join a lobby.
+     * <p>
+     * Returns nothing if the request could not be submitted i.e. not yet logged in.
+     * Otherwise, an {@link JoinLobbyCallback}.
+     *
+     * @param appId        ID of app the lobby belongs to.
+     * @param lobbySteamId The SteamID of the lobby that should be joined.
+     */
+    public void joinLobby(int appId, SteamID lobbySteamId) {
+        String personaName = client.getHandler(SteamFriends.class).getPersonaName();
+
+        if (personaName == null) {
+            return;
+        }
+
+        ClientMsgProtobuf<CMsgClientMMSJoinLobby.Builder> joinLobby =
+                new ClientMsgProtobuf<>(CMsgClientMMSJoinLobby.class, EMsg.ClientMMSJoinLobby);
+
+        CMsgClientMMSJoinLobby.Builder body = joinLobby
+                .getBody()
+                .setAppId(appId)
+                .setPersonaName(personaName)
+                .setSteamIdLobby(lobbySteamId.convertToUInt64());
+
+        joinLobby.setBody(body);
+        joinLobby.setSourceJobID(client.getNextJobID());
+
+        send(joinLobby, appId);
+    }
+
+    /**
+     * Sends a request to leave a lobby.
+     * <p>
+     * Returns an {@link  LeaveLobbyCallback}.
+     *
+     * @param appId        ID of app the lobby belongs to.
+     * @param lobbySteamId The SteamID of the lobby that should be left.
+     */
+    public void leaveLobby(int appId, SteamID lobbySteamId) {
+        ClientMsgProtobuf<CMsgClientMMSLeaveLobby.Builder> leaveLobby =
+                new ClientMsgProtobuf<>(CMsgClientMMSLeaveLobby.class, EMsg.ClientMMSLeaveLobby);
+
+        CMsgClientMMSLeaveLobby.Builder body = leaveLobby
+                .getBody()
+                .setAppId(appId)
+                .setSteamIdLobby(lobbySteamId.convertToUInt64());
+
+        leaveLobby.setBody(body);
+        leaveLobby.setSourceJobID(client.getNextJobID());
+
+        send(leaveLobby, appId);
+    }
+
+    /**
+     * Sends a request to obtain a lobby's data.
+     * <p>
+     * Returns an {@link LobbyDataCallback}
+     *
+     * @param appId        The ID of app which we're attempting to obtain lobby data for.
+     * @param lobbySteamId The SteamID of the lobby whose data is being requested.
+     */
+    public void getLobbyData(Integer appId, SteamID lobbySteamId) {
+        ClientMsgProtobuf<CMsgClientMMSGetLobbyData.Builder> getLobbyData =
+                new ClientMsgProtobuf<>(CMsgClientMMSGetLobbyData.class, EMsg.ClientMMSGetLobbyData);
+
+        CMsgClientMMSGetLobbyData.Builder body = getLobbyData
+                .getBody()
+                .setAppId(appId)
+                .setSteamIdLobby(lobbySteamId.convertToUInt64());
+
+        getLobbyData.setBody(body);
+        getLobbyData.setSourceJobID(client.getNextJobID());
+
+        send(getLobbyData, appId);
+    }
+
+    /**
+     * Sends a lobby invite request.
+     * NOTE: Steam provides no functionality to determine if the user was successfully invited.
+     *
+     * @param appId        The ID of app which owns the lobby we're inviting a user to.
+     * @param lobbySteamId The SteamID of the lobby we're inviting a user to.
+     * @param userSteamId  The SteamID of the user we're inviting.
+     */
+    public void inviteToLobby(int appId, SteamID lobbySteamId, SteamID userSteamId) {
+        ClientMsgProtobuf<CMsgClientMMSInviteToLobby.Builder> lobbyData =
+                new ClientMsgProtobuf<>(CMsgClientMMSInviteToLobby.class, EMsg.ClientMMSInviteToLobby);
+
+        CMsgClientMMSInviteToLobby.Builder body = lobbyData
+                .getBody()
+                .setAppId(appId)
+                .setSteamIdLobby(lobbySteamId.convertToUInt64())
+                .setSteamIdUserInvited(userSteamId.convertToUInt64());
+
+        lobbyData.setBody(body);
+
+        send(lobbyData, appId);
+    }
+
+    /**
+     * Obtains a {@link Lobby}, by its SteamID, if the data is cached locally.
+     * This method does not send a network request.
+     *
+     * @param appId        The ID of app which we're attempting to obtain a lobby for.
+     * @param lobbySteamId The SteamID of the lobby that should be returned.
+     * @return The {@link Lobby} corresponding with the specified app and lobby ID, if cached. Otherwise, <strong>null</strong>.
+     */
+    public Lobby getLobby(int appId, SteamID lobbySteamId) {
+        return lobbyCache.getLobby(appId, lobbySteamId);
+    }
+
+    /**
+     * Sends a matchmaking message for a specific app.
+     *
+     * @param msg   The matchmaking message to send.
+     * @param appId The ID of the app this message pertains to.
+     */
+    public void send(ClientMsgProtobuf<?> msg, int appId) {
+        if (msg == null) {
+            throw new NullPointerException("msg is null");
+        }
+
+        msg.getProtoHeader().setRoutingAppid(appId);
+        client.send(msg);
+    }
+
+    void clearLobbyCache() {
+        lobbyCache.clear();
+    }
+
+    /**
+     * Handles a client message. This should not be called directly.
+     *
+     * @param packetMsg The packet message that contains the data.
+     */
+    @Override
+    public void handleMsg(IPacketMsg packetMsg) {
+        if (packetMsg == null) {
+            throw new IllegalArgumentException("packetMsg is null");
+        }
+
+        Consumer<IPacketMsg> dispatcher = dispatchMap.get(packetMsg.getMsgType());
+        if (dispatcher != null) {
+            dispatcher.accept(packetMsg);
+        }
+    }
+
+    void handleCreateLobbyResponse(IPacketMsg packetMsg) {
+        ClientMsgProtobuf<CMsgClientMMSCreateLobbyResponse.Builder> createLobbyResponse =
+                new ClientMsgProtobuf<>(CMsgClientMMSCreateLobbyResponse.class, packetMsg);
+
+        CMsgClientMMSCreateLobbyResponse.Builder body = createLobbyResponse.getBody();
+
+        GeneratedMessageV3 request = lobbyManipulationRequests.remove(createLobbyResponse.getTargetJobID());
+
+        if (body.getEresult() == EResult.OK.code() && request != null) {
+            CMsgClientMMSCreateLobby createLobby = (CMsgClientMMSCreateLobby) request;
+
+            List<Lobby.Member> members = new ArrayList<>(1);
+
+            members.add(new Lobby.Member(client.getSteamID(), createLobby.getPersonaNameOwner(), null));
+
+            lobbyCache.cacheLobby(
+                    createLobby.getAppId(),
+                    new Lobby(
+                            new SteamID(body.getSteamIdLobby()),
+                            ELobbyType.from(createLobby.getLobbyType()),
+                            createLobby.getLobbyFlags(),
+                            client.getSteamID(),
+                            Lobby.decodeMetadata(createLobby.getMetadata().toByteArray()),
+                            createLobby.getMaxMembers(),
+                            1,
+                            members,
+                            null,
+                            null
+                    )
+            );
+        }
+
+        CreateLobbyCallback callback = new CreateLobbyCallback(
+                createLobbyResponse.getTargetJobID(),
+                body.getAppId(),
+                EResult.from(body.getEresult()),
+                new SteamID(body.getSteamIdLobby())
+        );
+        client.postCallback(callback);
+    }
+
+    void handleSetLobbyDataResponse(IPacketMsg packetMsg) {
+        ClientMsgProtobuf<CMsgClientMMSSetLobbyDataResponse.Builder> setLobbyDataResponse =
+                new ClientMsgProtobuf<>(CMsgClientMMSSetLobbyDataResponse.class, packetMsg);
+
+        CMsgClientMMSSetLobbyDataResponse.Builder body = setLobbyDataResponse.getBody();
+
+        GeneratedMessageV3 request = lobbyManipulationRequests.remove(setLobbyDataResponse.getTargetJobID());
+
+        if (body.getEresult() == EResult.OK.code() && request != null) {
+            CMsgClientMMSSetLobbyData setLobbyData = (CMsgClientMMSSetLobbyData) request;
+            Lobby lobby = lobbyCache.getLobby(setLobbyData.getAppId(), setLobbyData.getSteamIdLobby());
+
+            if (lobby != null) {
+                HashMap<String, String> metadata = Lobby.decodeMetadata(setLobbyData.getMetadata().toByteArray());
+
+                if (setLobbyData.getSteamIdMember() == 0) {
+                    lobbyCache.cacheLobby(
+                            setLobbyData.getAppId(),
+                            new Lobby(
+                                    lobby.getSteamID(),
+                                    ELobbyType.from(setLobbyData.getLobbyType()),
+                                    setLobbyData.getLobbyFlags(),
+                                    lobby.getOwnerSteamID(),
+                                    metadata,
+                                    setLobbyData.getMaxMembers(),
+                                    lobby.getNumMembers(),
+                                    lobby.getMembers(),
+                                    lobby.getDistance(),
+                                    lobby.getWeight()
+                            )
+                    );
+                } else {
+                    // I think this is right?
+                    List<Lobby.Member> members = new ArrayList<>();
+                    for (Lobby.Member member : lobby.getMembers()) {
+                        if (member.getSteamID().convertToUInt64() == setLobbyData.getSteamIdMember()) {
+                            members.add(new Lobby.Member(member.getSteamID(), member.getPersonaName(), metadata));
+                        } else {
+                            members.add(member);
+                        }
+                    }
+
+                    lobbyCache.updateLobbyMembers(setLobbyData.getAppId(), lobby, members);
+                }
+            }
+        }
+
+        SetLobbyDataCallback callback = new SetLobbyDataCallback(
+                setLobbyDataResponse.getTargetJobID(),
+                body.getAppId(),
+                EResult.from(body.getEresult()),
+                new SteamID(body.getSteamIdLobby())
+        );
+        client.postCallback(callback);
+    }
+
+    void handleSetLobbyOwnerResponse(IPacketMsg packetMsg) {
+        ClientMsgProtobuf<CMsgClientMMSSetLobbyOwnerResponse.Builder> setLobbyOwnerResponse =
+                new ClientMsgProtobuf<>(CMsgClientMMSSetLobbyOwnerResponse.class, packetMsg);
+
+        CMsgClientMMSSetLobbyOwnerResponse.Builder body = setLobbyOwnerResponse.getBody();
+
+        GeneratedMessageV3 request = lobbyManipulationRequests.remove(setLobbyOwnerResponse.getTargetJobID());
+
+        if (body.getEresult() == EResult.OK.code() && request != null) {
+            CMsgClientMMSSetLobbyOwner setLobbyOwner = (CMsgClientMMSSetLobbyOwner) request;
+            lobbyCache.updateLobbyOwner(body.getAppId(), body.getSteamIdLobby(), setLobbyOwner.getSteamIdNewOwner());
+        }
+
+        SetLobbyOwnerCallback callback = new SetLobbyOwnerCallback(
+                setLobbyOwnerResponse.getTargetJobID(),
+                body.getAppId(),
+                EResult.from(body.getEresult()),
+                new SteamID(body.getSteamIdLobby())
+        );
+        client.postCallback(callback);
+    }
+
+    void handleGetLobbyListResponse(IPacketMsg packetMsg) {
+        ClientMsgProtobuf<CMsgClientMMSGetLobbyListResponse.Builder> lobbyListResponse =
+                new ClientMsgProtobuf<>(CMsgClientMMSGetLobbyListResponse.class, packetMsg);
+
+        CMsgClientMMSGetLobbyListResponse.Builder body = lobbyListResponse.getBody();
+
+        List<Lobby> lobbyList = new ArrayList<>();
+        for (CMsgClientMMSGetLobbyListResponse.Lobby lobby : body.getLobbiesList()) {
+            Lobby existingLobby = lobbyCache.getLobby(body.getAppId(), lobby.getSteamId());
+            List<Lobby.Member> members = existingLobby.getMembers();
+
+            lobbyList.add(
+                    new Lobby(
+                            new SteamID(lobby.getSteamId()),
+                            ELobbyType.from(lobby.getLobbyType()),
+                            lobby.getLobbyFlags(),
+                            existingLobby.getOwnerSteamID(),
+                            Lobby.decodeMetadata(lobby.getMetadata().toByteArray()),
+                            lobby.getMaxMembers(),
+                            lobby.getNumMembers(),
+                            members,
+                            lobby.getDistance(),
+                            lobby.getWeight()
+                    )
+            );
+        }
+
+        for (Lobby lobby : lobbyList) {
+            lobbyCache.cacheLobby(body.getAppId(), lobby);
+        }
+
+        GetLobbyListCallback callback = new GetLobbyListCallback(
+                lobbyListResponse.getTargetJobID(),
+                body.getAppId(),
+                EResult.from(body.getAppId()),
+                lobbyList
+        );
+        client.postCallback(callback);
+    }
+
+    void handleJoinLobbyResponse(IPacketMsg packetMsg) {
+        ClientMsgProtobuf<CMsgClientMMSJoinLobbyResponse.Builder> joinLobbyResponse =
+                new ClientMsgProtobuf<>(CMsgClientMMSJoinLobbyResponse.class, packetMsg);
+
+        CMsgClientMMSJoinLobbyResponse.Builder body = joinLobbyResponse.getBody();
+
+        Lobby joinedLobby = null;
+
+        List<Lobby.Member> members = new ArrayList<>();
+        if (body.getSteamIdLobby() != 0L) { // This conditional could be problematic
+            for (CMsgClientMMSJoinLobbyResponse.Member member : body.getMembersList()) {
+                members.add(
+                        new Lobby.Member(
+                                member.getSteamId(),
+                                member.getPersonaName(),
+                                Lobby.decodeMetadata(member.getMetadata().toByteArray())
+                        )
+                );
+            }
+
+            Lobby cachedLobby = lobbyCache.getLobby(body.getAppId(), body.getSteamIdLobby());
+
+            joinedLobby = new Lobby(
+                    new SteamID(body.getSteamIdLobby()),
+                    ELobbyType.from(body.getLobbyType()),
+                    body.getLobbyFlags(),
+                    new SteamID(body.getSteamIdOwner()),
+                    Lobby.decodeMetadata(body.getMetadata().toByteArray()),
+                    body.getMaxMembers(),
+                    members.size(),
+                    members,
+                    cachedLobby.getDistance(),
+                    cachedLobby.getWeight()
+            );
+
+            lobbyCache.cacheLobby(body.getAppId(), joinedLobby);
+        }
+
+        JoinLobbyCallback callback = new JoinLobbyCallback(
+                joinLobbyResponse.getTargetJobID(),
+                body.getAppId(),
+                EChatRoomEnterResponse.from(body.getChatRoomEnterResponse()),
+                joinedLobby
+        );
+        client.postCallback(callback);
+    }
+
+    void handleLeaveLobbyResponse(IPacketMsg packetMsg) {
+        ClientMsgProtobuf<CMsgClientMMSLeaveLobbyResponse.Builder> leaveLobbyResponse =
+                new ClientMsgProtobuf<>(CMsgClientMMSLeaveLobbyResponse.class, packetMsg);
+
+        CMsgClientMMSLeaveLobbyResponse.Builder body = leaveLobbyResponse.getBody();
+
+        if (body.getEresult() == EResult.OK.code()) {
+            lobbyCache.clearLobbyMembers(body.getAppId(), body.getSteamIdLobby());
+        }
+
+        LeaveLobbyCallback callback = new LeaveLobbyCallback(
+                leaveLobbyResponse.getTargetJobID(),
+                body.getAppId(),
+                body.getEresult(),
+                body.getSteamIdLobby()
+        );
+        client.postCallback(callback);
+    }
+
+    void handleLobbyData(IPacketMsg packetMsg) {
+        ClientMsgProtobuf<CMsgClientMMSLobbyData.Builder> lobbyDataResponse =
+                new ClientMsgProtobuf<>(CMsgClientMMSLobbyData.class, packetMsg);
+
+        CMsgClientMMSLobbyData.Builder body = lobbyDataResponse.getBody();
+
+        Lobby cachedLobby = lobbyCache.getLobby(body.getAppId(), body.getSteamIdLobby());
+
+        List<Lobby.Member> members = new ArrayList<>();
+
+        if (!body.getMembersList().isEmpty()) {
+            for (CMsgClientMMSLobbyData.Member member : body.getMembersList()) {
+                members.add(
+                        new Lobby.Member(
+                                member.getSteamId(),
+                                member.getPersonaName(),
+                                Lobby.decodeMetadata(member.getMetadata().toByteArray()))
+                );
+            }
+        } else {
+            members = cachedLobby.getMembers();
+        }
+
+        Lobby updatedLobby = new Lobby(
+                new SteamID(body.getSteamIdLobby()),
+                ELobbyType.from(body.getLobbyType()),
+                body.getLobbyFlags(),
+                new SteamID(body.getSteamIdOwner()),
+                Lobby.decodeMetadata(body.getMetadata().toByteArray()),
+                body.getMaxMembers(),
+                body.getNumMembers(),
+                members,
+                cachedLobby.getDistance(),
+                cachedLobby.getWeight()
+        );
+
+        lobbyCache.cacheLobby(body.getAppId(), updatedLobby);
+
+        LobbyDataCallback callback = new LobbyDataCallback(lobbyDataResponse.getTargetJobID(), body.getAppId(), updatedLobby);
+        client.postCallback(callback);
+    }
+
+    void handleUserJoinedLobby(IPacketMsg packetMsg) {
+        ClientMsgProtobuf<CMsgClientMMSUserJoinedLobby.Builder> userJoinedLobby =
+                new ClientMsgProtobuf<>(CMsgClientMMSUserJoinedLobby.class, packetMsg);
+
+        CMsgClientMMSUserJoinedLobby.Builder body = userJoinedLobby.getBody();
+
+        Lobby lobby = lobbyCache.getLobby(body.getAppId(), body.getSteamIdLobby());
+
+        if (lobby != null && lobby.getMembers().size() > 0) {
+            Lobby.Member joiningMember = lobbyCache.addLobbyMember(body.getAppId(), lobby, body.getSteamIdUser(), body.getPersonaName());
+
+            if (joiningMember != null) {
+                UserJoinedLobbyCallback callback = new UserJoinedLobbyCallback(body.getAppId(), body.getSteamIdLobby(), joiningMember);
+
+                client.postCallback(callback);
+            }
+        }
+    }
+
+    void handleUserLeftLobby(IPacketMsg packetMsg) {
+        ClientMsgProtobuf<CMsgClientMMSUserLeftLobby.Builder> userLeftLobby =
+                new ClientMsgProtobuf<>(CMsgClientMMSUserLeftLobby.class, packetMsg);
+
+        CMsgClientMMSUserLeftLobby.Builder body = userLeftLobby.getBody();
+
+        Lobby lobby = lobbyCache.getLobby(body.getAppId(), body.getSteamIdLobby());
+
+        if (lobby != null && lobby.getMembers().size() > 0) {
+            Lobby.Member leavingMember = lobbyCache.removeLobbyMember(body.getAppId(), lobby, body.getSteamIdUser());
+            if (leavingMember == null) {
+                return;
+            }
+
+            if (leavingMember.getSteamID() == client.getSteamID()) {
+                lobbyCache.clearLobbyMembers(body.getAppId(), body.getSteamIdLobby());
+            }
+
+            UserLeftLobbyCallback callback = new UserLeftLobbyCallback(body.getAppId(), body.getSteamIdLobby(), leavingMember);
+            client.postCallback(callback);
+        }
+    }
+}

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steammatchmaking/callback/CreateLobbyCallback.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steammatchmaking/callback/CreateLobbyCallback.java
@@ -1,0 +1,50 @@
+package in.dragonbra.javasteam.steam.handlers.steammatchmaking.callback;
+
+import in.dragonbra.javasteam.enums.EResult;
+import in.dragonbra.javasteam.steam.steamclient.callbackmgr.CallbackMsg;
+import in.dragonbra.javasteam.types.JobID;
+import in.dragonbra.javasteam.types.SteamID;
+
+/**
+ * This callback is fired in response to
+ * {@link in.dragonbra.javasteam.steam.handlers.steammatchmaking.SteamMatchmaking#createLobby}.
+ *
+ * @author lossy
+ * @since 2022-06-21
+ */
+public class CreateLobbyCallback extends CallbackMsg {
+
+    /**
+     * ID of the app the created lobby belongs to.
+     */
+    private int appId;
+
+    /**
+     * The result of the request.
+     */
+    private EResult result;
+
+    /**
+     * The SteamID of the created lobby.
+     */
+    private SteamID lobbySteamID;
+
+    public CreateLobbyCallback(JobID jobID, int appId, EResult result, SteamID lobbySteamID) {
+        this.setJobID(jobID);
+        this.appId = appId;
+        this.result = result;
+        this.lobbySteamID = lobbySteamID;
+    }
+
+    public int getAppId() {
+        return appId;
+    }
+
+    public EResult getResult() {
+        return result;
+    }
+
+    public SteamID getLobbySteamID() {
+        return lobbySteamID;
+    }
+}

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steammatchmaking/callback/GetLobbyListCallback.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steammatchmaking/callback/GetLobbyListCallback.java
@@ -1,0 +1,53 @@
+package in.dragonbra.javasteam.steam.handlers.steammatchmaking.callback;
+
+import in.dragonbra.javasteam.enums.EResult;
+import in.dragonbra.javasteam.steam.handlers.steammatchmaking.Lobby;
+import in.dragonbra.javasteam.steam.steamclient.callbackmgr.CallbackMsg;
+import in.dragonbra.javasteam.types.JobID;
+
+import java.util.List;
+
+/**
+ * This callback is fired in response to
+ * {@link in.dragonbra.javasteam.steam.handlers.steammatchmaking.SteamMatchmaking#getLobbyList}.
+ *
+ * @author lossy
+ * @since 2022-06-21
+ */
+public class GetLobbyListCallback extends CallbackMsg {
+
+    /**
+     * ID of the app the lobbies belongs to.
+     */
+    private int appId;
+
+    /**
+     * The result of the request.
+     */
+    private EResult result;
+
+    /**
+     * The list of lobbies matching the criteria specified with
+     * {@link in.dragonbra.javasteam.steam.handlers.steammatchmaking.SteamMatchmaking#getLobbyList}.
+     */
+    private List<Lobby> lobbies;
+
+    public GetLobbyListCallback(JobID jobID, int appId, EResult result, List<Lobby> lobbies) {
+        this.setJobID(jobID);
+        this.appId = appId;
+        this.result = result;
+        this.lobbies = lobbies;
+    }
+
+    public int getAppId() {
+        return appId;
+    }
+
+    public EResult getResult() {
+        return result;
+    }
+
+    public List<Lobby> getLobbies() {
+        return lobbies;
+    }
+}

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steammatchmaking/callback/JoinLobbyCallback.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steammatchmaking/callback/JoinLobbyCallback.java
@@ -1,0 +1,52 @@
+package in.dragonbra.javasteam.steam.handlers.steammatchmaking.callback;
+
+import in.dragonbra.javasteam.enums.EChatRoomEnterResponse;
+import in.dragonbra.javasteam.steam.handlers.steammatchmaking.Lobby;
+import in.dragonbra.javasteam.steam.steamclient.callbackmgr.CallbackMsg;
+import in.dragonbra.javasteam.types.JobID;
+
+/**
+ * This callback is fired in response to
+ * {@link in.dragonbra.javasteam.steam.handlers.steammatchmaking.SteamMatchmaking#joinLobby}.
+ *
+ * @author lossy
+ * @since 2022-06-21
+ */
+public class JoinLobbyCallback extends CallbackMsg {
+
+    /**
+     * ID of the app the targeted lobby belongs to.
+     */
+    private int appId;
+
+    /**
+     * The result of the request.
+     */
+    private EChatRoomEnterResponse chatRoomEnterResponse;
+
+    /**
+     * The joined {@link Lobby}, when {@link JoinLobbyCallback#chatRoomEnterResponse} equals
+     * <see cref="EChatRoomEnterResponse.Success"/>, otherwise <c>null</c>
+     */
+    private Lobby lobby;
+
+    public JoinLobbyCallback(JobID jobID, int appId, EChatRoomEnterResponse response, Lobby lobby) {
+        this.setJobID(jobID);
+        this.appId = appId;
+        this.chatRoomEnterResponse = response;
+        this.lobby = lobby;
+    }
+
+
+    public int getAppId() {
+        return appId;
+    }
+
+    public EChatRoomEnterResponse getChatRoomEnterResponse() {
+        return chatRoomEnterResponse;
+    }
+
+    public Lobby getLobby() {
+        return lobby;
+    }
+}

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steammatchmaking/callback/LeaveLobbyCallback.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steammatchmaking/callback/LeaveLobbyCallback.java
@@ -1,0 +1,50 @@
+package in.dragonbra.javasteam.steam.handlers.steammatchmaking.callback;
+
+import in.dragonbra.javasteam.enums.EResult;
+import in.dragonbra.javasteam.steam.steamclient.callbackmgr.CallbackMsg;
+import in.dragonbra.javasteam.types.JobID;
+import in.dragonbra.javasteam.types.SteamID;
+
+/**
+ * This callback is fired in response to
+ * {@link in.dragonbra.javasteam.steam.handlers.steammatchmaking.SteamMatchmaking#leaveLobby}
+ *
+ * @author lossy
+ * @since 2022-06-21
+ */
+public class LeaveLobbyCallback extends CallbackMsg {
+
+    /**
+     * ID of the app the targeted lobby belongs to.
+     */
+    private int appId;
+
+    /**
+     * The result of the request.
+     */
+    private EResult result;
+
+    /**
+     * The SteamID of the targeted Lobby.
+     */
+    private SteamID lobbySteamID;
+
+    public LeaveLobbyCallback(JobID jobID, int appId, int result, long lobbySteamID) {
+        this.setJobID(jobID);
+        this.appId = appId;
+        this.result = EResult.from(result);
+        this.lobbySteamID = new SteamID(lobbySteamID);
+    }
+
+    public int getAppId() {
+        return appId;
+    }
+
+    public EResult getResult() {
+        return result;
+    }
+
+    public SteamID getLobbySteamID() {
+        return lobbySteamID;
+    }
+}

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steammatchmaking/callback/LobbyDataCallback.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steammatchmaking/callback/LobbyDataCallback.java
@@ -1,0 +1,40 @@
+package in.dragonbra.javasteam.steam.handlers.steammatchmaking.callback;
+
+import in.dragonbra.javasteam.steam.handlers.steammatchmaking.Lobby;
+import in.dragonbra.javasteam.steam.steamclient.callbackmgr.CallbackMsg;
+import in.dragonbra.javasteam.types.JobID;
+
+/**
+ * This callback is fired in response to
+ * {@link in.dragonbra.javasteam.steam.handlers.steammatchmaking.SteamMatchmaking#getLobbyData},
+ * as well as whenever Steam sends us updated lobby data.
+ *
+ * @author lossy
+ * @since 2022-06-21
+ */
+public class LobbyDataCallback extends CallbackMsg {
+
+    /**
+     * ID of the app the updated lobby belongs to.
+     */
+    private int appId;
+
+    /**
+     * The lobby that was updated.
+     */
+    private Lobby lobby;
+
+    public LobbyDataCallback(JobID jobID, int appId, Lobby lobby) {
+        this.setJobID(jobID);
+        this.appId = appId;
+        this.lobby = lobby;
+    }
+
+    public int getAppId() {
+        return appId;
+    }
+
+    public Lobby getLobby() {
+        return lobby;
+    }
+}

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steammatchmaking/callback/SetLobbyDataCallback.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steammatchmaking/callback/SetLobbyDataCallback.java
@@ -1,0 +1,50 @@
+package in.dragonbra.javasteam.steam.handlers.steammatchmaking.callback;
+
+import in.dragonbra.javasteam.enums.EResult;
+import in.dragonbra.javasteam.steam.steamclient.callbackmgr.CallbackMsg;
+import in.dragonbra.javasteam.types.JobID;
+import in.dragonbra.javasteam.types.SteamID;
+
+/**
+ * This callback is fired in response to
+ * {@link in.dragonbra.javasteam.steam.handlers.steammatchmaking.SteamMatchmaking#setLobbyData}.
+ *
+ * @author lossy
+ * @since 2022-06-21
+ */
+public class SetLobbyDataCallback extends CallbackMsg {
+
+    /**
+     * ID of the app the targeted lobby belongs to.
+     */
+    private int appId;
+
+    /**
+     * The result of the request.
+     */
+    private EResult result;
+
+    /**
+     * The SteamID of the targeted Lobby.
+     */
+    private SteamID lobbySteamID;
+
+    public SetLobbyDataCallback(JobID jobID, int appId, EResult result, SteamID lobbySteamID) {
+        this.setJobID(jobID);
+        this.appId = appId;
+        this.result = result;
+        this.lobbySteamID = lobbySteamID;
+    }
+
+    public int getAppId() {
+        return appId;
+    }
+
+    public EResult getResult() {
+        return result;
+    }
+
+    public SteamID getLobbySteamID() {
+        return lobbySteamID;
+    }
+}

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steammatchmaking/callback/SetLobbyOwnerCallback.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steammatchmaking/callback/SetLobbyOwnerCallback.java
@@ -1,0 +1,50 @@
+package in.dragonbra.javasteam.steam.handlers.steammatchmaking.callback;
+
+import in.dragonbra.javasteam.enums.EResult;
+import in.dragonbra.javasteam.steam.steamclient.callbackmgr.CallbackMsg;
+import in.dragonbra.javasteam.types.JobID;
+import in.dragonbra.javasteam.types.SteamID;
+
+/**
+ * This callback is fired in response to
+ * {@link in.dragonbra.javasteam.steam.handlers.steammatchmaking.SteamMatchmaking#setLobbyOwner}.
+ *
+ * @author lossy
+ * @since 2022-06-21
+ */
+public class SetLobbyOwnerCallback extends CallbackMsg {
+
+    /**
+     * ID of the app the targeted lobby belongs to.
+     */
+    private int appId;
+
+    /**
+     * The result of the request.
+     */
+    private EResult result;
+
+    /**
+     * The SteamID of the targeted Lobby.
+     */
+    private SteamID lobbySteamID;
+
+    public SetLobbyOwnerCallback(JobID jobID, int appId, EResult result, SteamID lobbySteamID) {
+        this.setJobID(jobID);
+        this.appId = appId;
+        this.result = result;
+        this.lobbySteamID = lobbySteamID;
+    }
+
+    public int getAppId() {
+        return appId;
+    }
+
+    public EResult getResult() {
+        return result;
+    }
+
+    public SteamID getLobbySteamID() {
+        return lobbySteamID;
+    }
+}

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steammatchmaking/callback/UserJoinedLobbyCallback.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steammatchmaking/callback/UserJoinedLobbyCallback.java
@@ -1,0 +1,47 @@
+package in.dragonbra.javasteam.steam.handlers.steammatchmaking.callback;
+
+import in.dragonbra.javasteam.steam.handlers.steammatchmaking.Lobby;
+import in.dragonbra.javasteam.steam.steamclient.callbackmgr.CallbackMsg;
+import in.dragonbra.javasteam.types.SteamID;
+
+/**
+ * This callback is fired whenever Steam informs us a user has joined a lobby.
+ *
+ * @author lossy
+ * @since 2022-06-21
+ */
+public class UserJoinedLobbyCallback extends CallbackMsg {
+
+    /**
+     * ID of the app the lobby belongs to.
+     */
+    private int appId;
+
+    /**
+     * The SteamID of the lobby that a member joined.
+     */
+    private SteamID lobbySteamID;
+
+    /**
+     * The lobby member that joined.
+     */
+    private Lobby.Member user;
+
+    public UserJoinedLobbyCallback(int appId, long lobbySteamID, Lobby.Member user) {
+        this.appId = appId;
+        this.lobbySteamID = new SteamID(lobbySteamID);
+        this.user = user;
+    }
+
+    public int getAppId() {
+        return appId;
+    }
+
+    public SteamID getLobbySteamID() {
+        return lobbySteamID;
+    }
+
+    public Lobby.Member getUser() {
+        return user;
+    }
+}

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steammatchmaking/callback/UserLeftLobbyCallback.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steammatchmaking/callback/UserLeftLobbyCallback.java
@@ -1,0 +1,47 @@
+package in.dragonbra.javasteam.steam.handlers.steammatchmaking.callback;
+
+import in.dragonbra.javasteam.steam.handlers.steammatchmaking.Lobby;
+import in.dragonbra.javasteam.steam.steamclient.callbackmgr.CallbackMsg;
+import in.dragonbra.javasteam.types.SteamID;
+
+/**
+ * This callback is fired whenever Steam informs us a user has left a lobby.
+ *
+ * @author lossy
+ * @since 2022-06-21
+ */
+public class UserLeftLobbyCallback extends CallbackMsg {
+
+    /**
+     * ID of the app the lobby belongs to.
+     */
+    private int appId;
+
+    /**
+     * The SteamID of the lobby that a member left.
+     */
+    private SteamID lobbySteamID;
+
+    /**
+     * The lobby member that left.
+     */
+    private Lobby.Member user;
+
+    public UserLeftLobbyCallback(int appId, long lobbySteamID, Lobby.Member user) {
+        this.appId = appId;
+        this.lobbySteamID = new SteamID(lobbySteamID);
+        this.user = user;
+    }
+
+    public int getAppId() {
+        return appId;
+    }
+
+    public SteamID getLobbySteamID() {
+        return lobbySteamID;
+    }
+
+    public Lobby.Member getUser() {
+        return user;
+    }
+}

--- a/src/main/java/in/dragonbra/javasteam/steam/steamclient/SteamClient.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/steamclient/SteamClient.java
@@ -81,6 +81,7 @@ public class SteamClient extends CMClient {
         addHandler(new SteamMasterServer());
         addHandler(new SteamGameServer());
         addHandler(new SteamGameCoordinator());
+        // addHandler(new SteamMatchmaking()); // Untested.
 
         processStartTime = new Date();
 

--- a/src/main/java/in/dragonbra/javasteam/util/NetHelpers.java
+++ b/src/main/java/in/dragonbra/javasteam/util/NetHelpers.java
@@ -1,5 +1,6 @@
 package in.dragonbra.javasteam.util;
 
+import in.dragonbra.javasteam.protobufs.steamclient.SteammessagesBase;
 import org.apache.commons.validator.routines.InetAddressValidator;
 
 import java.net.InetAddress;
@@ -12,6 +13,23 @@ import java.nio.ByteBuffer;
  * @since 2018-02-22
  */
 public class NetHelpers {
+
+    public static SteammessagesBase.CMsgIPAddress getMsgIPAddress(InetAddress ipAddr) {
+        SteammessagesBase.CMsgIPAddress.Builder msgIpAddress = SteammessagesBase.CMsgIPAddress.newBuilder();
+        byte[] addrBytes = ipAddr.getAddress();
+
+        msgIpAddress.setV4(ByteBuffer.wrap(addrBytes).get());
+
+        return msgIpAddress.build();
+    }
+
+    public static InetAddress getIPAddress(SteammessagesBase.CMsgIPAddress ipAddress) {
+        return NetHelpers.getIPAddress(ipAddress.getV4());
+        // TODO handle ipV6 sometime
+        // if (ipAddress.hasV6()) {
+        // } else {
+        // }
+    }
 
     public static InetAddress getIPAddress(int ipAddr) {
         ByteBuffer b = ByteBuffer.allocate(4);

--- a/src/test/java/in/dragonbra/javasteam/steam/handlers/steamfriends/FriendCacheTest.java
+++ b/src/test/java/in/dragonbra/javasteam/steam/handlers/steamfriends/FriendCacheTest.java
@@ -1,0 +1,138 @@
+package in.dragonbra.javasteam.steam.handlers.steamfriends;
+
+import in.dragonbra.javasteam.enums.EClanRelationship;
+import in.dragonbra.javasteam.enums.EFriendRelationship;
+import in.dragonbra.javasteam.enums.EPersonaState;
+import in.dragonbra.javasteam.enums.EPersonaStateFlag;
+import in.dragonbra.javasteam.steam.handlers.HandlerTestBase;
+import in.dragonbra.javasteam.types.GameID;
+import in.dragonbra.javasteam.types.SteamID;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.EnumSet;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author lossy
+ * @since 2022-06-21
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class FriendCacheTest extends HandlerTestBase<SteamFriends> {
+
+    @Override
+    protected SteamFriends createHandler() {
+        return new SteamFriends();
+    }
+
+    @Test
+    public void testAbstractAccountClass() {
+        FriendCache.User abstractAccount = new FriendCache.User();
+
+        SteamID steamID = new SteamID(76561198003805806L);
+        String avatarHash = "cfa928ab4119dd137e50d728e8fe703e4e970aff";
+
+        // add random info to User.
+        abstractAccount.setSteamID(steamID);
+        abstractAccount.setName("Some Abstract Name");
+        abstractAccount.setAvatarHash(avatarHash.getBytes());
+
+        assertEquals(76561198003805806L, abstractAccount.getSteamID().convertToUInt64());
+        assertEquals("Some Abstract Name", abstractAccount.getName());
+        assertEquals(avatarHash, new String(abstractAccount.getAvatarHash()));
+    }
+
+    @Test
+    public void testUserCacheAccount() {
+        FriendCache.User user = new FriendCache.User();
+
+        GameID gameID = new GameID(420, "Research and Development");
+        EnumSet<EPersonaStateFlag> stateFlags = EnumSet.of(EPersonaStateFlag.ClientTypeVR);
+
+        // add random info to User.
+        user.setRelationship(EFriendRelationship.Friend);
+        user.setPersonaState(EPersonaState.Online);
+        user.setPersonaStateFlags(stateFlags);
+        user.setGameAppID(420);
+        user.setGameID(gameID);
+        user.setGameName("Some Game");
+
+        assertEquals(EFriendRelationship.Friend, user.getRelationship());
+        assertEquals(EPersonaState.Online, user.getPersonaState());
+        assertTrue(user.getPersonaStateFlags().contains(EPersonaStateFlag.ClientTypeVR));
+        assertEquals(420, user.getGameAppID());
+        assertTrue(user.getGameID().isMod());
+        assertEquals(420, user.getGameID().getAppID());
+        assertEquals(new GameID(0x8db24e81010001a4L), user.getGameID());
+        assertEquals("Some Game", user.getGameName());
+    }
+
+    @Test
+    public void testClanCacheAccount() {
+        FriendCache.Clan clan = new FriendCache.Clan();
+
+        // add random info to Clan
+        clan.setRelationship(EClanRelationship.PendingApproval);
+
+        assertEquals(EClanRelationship.PendingApproval, clan.getRelationship());
+    }
+
+    /**
+     * Test coverage for {@link FriendCache.AccountCache}.
+     * <p>
+     * Mostly to verify both Type Erasure and ConcurrentHashMap work, see {@link FriendCache.AccountList}
+     */
+    @Test
+    public void textAccountClass() {
+        FriendCache.AccountCache accountCache = new FriendCache.AccountCache();
+
+        /* Test Clan Stuff */
+        SteamID clan1 = new SteamID(103582791434671111L);
+        SteamID clan2 = new SteamID(103582791429522222L);
+        SteamID clan3 = new SteamID(103582791429523333L);
+
+        assertTrue(clan1.isClanAccount());
+        assertTrue(clan2.isClanAccount());
+        assertTrue(clan3.isClanAccount());
+
+        FriendCache.Clan clan1exist = accountCache.getClan(clan1);
+        FriendCache.Clan clan2exist = accountCache.getClan(clan2);
+        FriendCache.Clan clan3exist = accountCache.getClan(clan3);
+
+        assertTrue(accountCache.getClans().contains(clan1exist));
+        assertTrue(accountCache.getClans().contains(clan2exist));
+        assertTrue(accountCache.getClans().contains(clan3exist));
+        assertEquals(clan1,  clan1exist.getSteamID());
+        assertEquals(clan2,  clan2exist.getSteamID());
+        assertEquals(clan3,  clan3exist.getSteamID());
+
+        assertEquals(3, accountCache.getClans().size());
+
+        /* Test User Stuff */
+        SteamID user1 = new SteamID(76561197960265700L);
+        SteamID user2 = new SteamID(76561197960265711L);
+
+        assertTrue(user1.isIndividualAccount());
+        assertTrue(user2.isIndividualAccount());
+
+        FriendCache.User user1Exist = accountCache.getUser(user1);
+        FriendCache.User user2Exist = accountCache.getUser(user2);
+
+        assertTrue(accountCache.getUsers().contains(user1Exist));
+        assertTrue(accountCache.getUsers().contains(user2Exist));
+        assertEquals(user1, user1Exist.getSteamID());
+        assertEquals(user2, user2Exist.getSteamID());
+
+        assertEquals(2, accountCache.getUsers().size());
+
+        /* Test Local User */
+        SteamID localSteamID = steamClient.getSteamID();
+        accountCache.getLocalUser().setSteamID(localSteamID);
+
+        assertTrue(accountCache.isLocalUser(localSteamID));
+        assertSame(localSteamID, accountCache.getLocalUser().getSteamID());
+        assertSame(localSteamID, accountCache.getUser(localSteamID).getSteamID());
+    }
+}


### PR DESCRIPTION
### Description
From PR 704 on SteamKit

Add SteamMatchmaking - creating, retrieving, listing, joining and leaving lobbies.

Note: I only made up a quick unit test for FriendCache.java. Everything else has no unit testing and should be considered **_unstable_** until proven. 

I havent done physical testing myself, and this is a backport from Java 11. 

Closes #70 

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
