### PR TITLE
Cleanup JavaGen

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ sourceSets {
         java {
             srcDirs += new File(buildDir, 'generated/source/steamd/main/java')
             srcDirs += new File(buildDir, 'generated/source/proto/main/java')
-            srcDirs += new File(buildDir, 'generated/source/in/dragonbra/javasteam')
+            srcDirs += new File(buildDir, 'generated/source/javasteam/main/java')
         }
     }
 }
@@ -84,7 +84,8 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 task generatVersionClass {
-    def outputDir = file("$buildDir/generated/source/in/dragonbra/javasteam/util")
+    def generatedDir = file("$buildDir/generated/source/javasteam/main/java")
+    def outputDir = file("$generatedDir/in/dragonbra/javasteam/util")
     outputs.dir outputDir
     doFirst {
         outputDir.exists() || outputDir.mkdirs()

--- a/buildSrc/src/main/groovy/in/dragonbra/steamlanguagegen/generator/JavaGen.groovy
+++ b/buildSrc/src/main/groovy/in/dragonbra/steamlanguagegen/generator/JavaGen.groovy
@@ -80,7 +80,7 @@ class JavaGen implements Closeable, Flushable {
                 if (node.name.contains('MsgGC')) {
                     imports << 'in.dragonbra.javasteam.base.IGCSerializableHeader'
                 } else {
-                    imports << 'in.dragonbra.javasteam.base.ISteamSerializableHeader' << 'in.dragonbra.javasteam.enums.EMsg'
+                    imports << 'in.dragonbra.javasteam.base.ISteamSerializableHeader'
                 }
             } else {
                 imports << 'in.dragonbra.javasteam.base.ISteamSerializable'
@@ -101,7 +101,6 @@ class JavaGen implements Closeable, Flushable {
                 } else if (prop.flags == 'proto') {
                     imports << 'in.dragonbra.javasteam.protobufs.steamclient.SteammessagesBase.CMsgProtoBufHeader'
                 } else if (prop.flags == 'protomask') {
-                    imports << 'in.dragonbra.javasteam.enums.EMsg'
                     imports << 'in.dragonbra.javasteam.util.MsgUtil'
                 }
 


### PR DESCRIPTION
### Description

Versions generator now places file in correct package path. 

Tweaked JavaGen to stop duping EMsg imports in `MsgHdrProtoBuf` and `MsgHdr`

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
