### PR TITLE
Remove sent/recv debug messages

### DIFF
--- a/src/main/java/in/dragonbra/javasteam/steam/CMClient.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/CMClient.java
@@ -206,8 +206,6 @@ public abstract class CMClient {
             msg.setSteamID(_steamID);
         }
 
-        logger.debug(String.format("Sent -> EMsg: %s (Proto: %s)", msg.getMsgType(), msg.isProto()));
-
         try {
             if (debugNetworkListener != null) {
                 debugNetworkListener.onOutgoingNetworkMessage(msg.getMsgType(), msg.serialize());
@@ -246,8 +244,6 @@ public abstract class CMClient {
             disconnect();
             return false;
         }
-
-        logger.debug(String.format("<- Recv'd EMsg: %s (%d) (Proto: %s)", packetMsg.getMsgType(), packetMsg.getMsgType().code(), packetMsg.isProto()));
 
         // Multi message gets logged down the line after it's decompressed
         if (packetMsg.getMsgType() != EMsg.Multi) {

--- a/src/main/java/in/dragonbra/javasteam/util/NetHookNetworkListener.java
+++ b/src/main/java/in/dragonbra/javasteam/util/NetHookNetworkListener.java
@@ -15,7 +15,7 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * Dump any network messages sent to and received from the Steam server that the client is connected to.
  * These messages are dumped to file, and can be analyzed further with NetHookAnalyzer, a hex editor, or your own purpose-built tools.
- *
+ * <p>
  * Be careful with this, sensitive data may be written to the disk (such as your Steam password).
  */
 public class NetHookNetworkListener implements IDebugNetworkListener {
@@ -42,6 +42,8 @@ public class NetHookNetworkListener implements IDebugNetworkListener {
 
     @Override
     public void onIncomingNetworkMessage(EMsg msgType, byte[] data) {
+        logger.debug(String.format("<- Recv'd EMsg: %s (%d)", msgType, msgType.code()));
+
         try {
             Files.write(Paths.get(new File(logDirectory, getFile("in", msgType)).getAbsolutePath()), data);
         } catch (IOException e) {
@@ -51,6 +53,8 @@ public class NetHookNetworkListener implements IDebugNetworkListener {
 
     @Override
     public void onOutgoingNetworkMessage(EMsg msgType, byte[] data) {
+        logger.debug(String.format("Sent -> EMsg: %s", msgType));
+
         try {
             Files.write(Paths.get(new File(logDirectory, getFile("out", msgType)).getAbsolutePath()), data);
         } catch (IOException e) {


### PR DESCRIPTION
### Description
`CMClient.debugNetworkListener` can be used for this purpose.

This will actually make DebugLog easier to enable without having to worry about the packet spam.

Sample 3 demonstrates how to enable this. 

Closes #102 

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
