### PR TITLE
Remove only_public from pics requests, update picsGetProductInfo 

### DIFF
--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamapps/PICSRequest.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamapps/PICSRequest.java
@@ -9,13 +9,11 @@ public class PICSRequest {
 
     private long accessToken;
 
-    private boolean _public;
-
     /**
      * Instantiate a PICS product info request
      */
     public PICSRequest() {
-        this(0, 0L, true);
+        this(0, 0L);
     }
 
     /**
@@ -24,7 +22,7 @@ public class PICSRequest {
      * @param id App or package ID\
      */
     public PICSRequest(int id) {
-        this(id, 0L, true);
+        this(id, 0L);
     }
 
     /**
@@ -32,12 +30,10 @@ public class PICSRequest {
      *
      * @param id          App or package ID
      * @param accessToken PICS access token
-     * @param _public     Get only public info
      */
-    public PICSRequest(int id, long accessToken, boolean _public) {
+    public PICSRequest(int id, long accessToken) {
         this.id = id;
         this.accessToken = accessToken;
-        this._public = _public;
     }
 
     /**
@@ -66,19 +62,5 @@ public class PICSRequest {
      */
     public void setAccessToken(long accessToken) {
         this.accessToken = accessToken;
-    }
-
-    /**
-     * @return The flag specifying if only public data is requested
-     */
-    public boolean isPublic() {
-        return _public;
-    }
-
-    /**
-     * @param _public The flag specifying if only public data is requested
-     */
-    public void setPublic(boolean _public) {
-        this._public = _public;
     }
 }

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamapps/SteamApps.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamapps/SteamApps.java
@@ -281,22 +281,8 @@ public class SteamApps extends ClientMsgHandler {
      * @param _package Package id requested.
      * @return The Job ID of the request. This can be used to find the appropriate {@link PICSProductInfoCallback}.
      */
-    public JobID picsGetProductInfo(Integer app, Integer _package) {
-        return picsGetProductInfo(app, _package, true, false);
-    }
-
-
-    /**
-     * Request product information for an app or package
-     * Results are returned in a {@link PICSProductInfoCallback} callback.
-     *
-     * @param app        App id requested.
-     * @param _package   Package id requested.
-     * @param onlyPublic Whether to send only public information.
-     * @return The Job ID of the request. This can be used to find the appropriate {@link PICSProductInfoCallback}.
-     */
-    public JobID picsGetProductInfo(Integer app, Integer _package, boolean onlyPublic) {
-        return picsGetProductInfo(app, _package, onlyPublic, false);
+    public JobID picsGetProductInfo(PICSRequest app, PICSRequest _package) {
+        return picsGetProductInfo(app, _package, false);
     }
 
     /**
@@ -305,13 +291,12 @@ public class SteamApps extends ClientMsgHandler {
      *
      * @param app          App id requested.
      * @param _package     Package id requested.
-     * @param onlyPublic   Whether to send only public information.
      * @param metaDataOnly Whether to send only meta data.
      * @return The Job ID of the request. This can be used to find the appropriate {@link PICSProductInfoCallback}.
      */
-    public JobID picsGetProductInfo(Integer app, Integer _package, boolean onlyPublic, boolean metaDataOnly) {
-        List<Integer> apps = new ArrayList<>();
-        List<Integer> packages = new ArrayList<>();
+    public JobID picsGetProductInfo(PICSRequest app, PICSRequest _package, boolean metaDataOnly) {
+        List<PICSRequest> apps = new ArrayList<>();
+        List<PICSRequest> packages = new ArrayList<>();
 
         if (app != null) {
             apps.add(app);
@@ -321,7 +306,7 @@ public class SteamApps extends ClientMsgHandler {
             packages.add(_package);
         }
 
-        return picsGetProductInfo(apps, packages, onlyPublic, metaDataOnly);
+        return picsGetProductInfo(apps, packages, metaDataOnly);
     }
 
     /**
@@ -332,34 +317,8 @@ public class SteamApps extends ClientMsgHandler {
      * @param packages List of package ids requested.
      * @return The Job ID of the request. This can be used to find the appropriate {@link PICSProductInfoCallback}.
      */
-    public JobID picsGetProductInfo(Iterable<Integer> apps, Iterable<Integer> packages) {
-        return picsGetProductInfo(apps, packages, true, false);
-    }
-
-    /**
-     * Request product information for a list of apps or packages
-     * Results are returned in a {@link PICSProductInfoCallback} callback.
-     *
-     * @param apps         List of app ids requested.
-     * @param packages     List of package ids requested.
-     * @param onlyPublic   Whether to send only public information.
-     * @param metaDataOnly Whether to send only meta data.
-     * @return The Job ID of the request. This can be used to find the appropriate {@link PICSProductInfoCallback}.
-     */
-    public JobID picsGetProductInfo(Iterable<Integer> apps, Iterable<Integer> packages, boolean onlyPublic, boolean metaDataOnly) {
-        List<PICSRequest> appRequests = new ArrayList<>();
-        List<PICSRequest> packageRequests = new ArrayList<>();
-
-        for (Integer app : apps) {
-            appRequests.add(new PICSRequest(app, 0, onlyPublic));
-        }
-
-        for (Integer _package : packages) {
-            packageRequests.add(new PICSRequest(_package, 0, onlyPublic));
-        }
-
-        return picsGetProductInfo(appRequests, packageRequests, metaDataOnly);
-
+    public JobID picsGetProductInfo(Iterable<PICSRequest> apps, Iterable<PICSRequest> packages) {
+        return picsGetProductInfo(apps, packages, false);
     }
 
     /**
@@ -390,7 +349,7 @@ public class SteamApps extends ClientMsgHandler {
 
             appInfo.setAccessToken(appRequest.getAccessToken());
             appInfo.setAppid(appRequest.getId());
-            appInfo.setOnlyPublicObsolete(appRequest.isPublic());
+            appInfo.setOnlyPublicObsolete(false);
 
             request.getBody().addApps(appInfo);
         }

--- a/src/test/java/in/dragonbra/javasteam/steam/handlers/steamapps/SteamAppsTest.java
+++ b/src/test/java/in/dragonbra/javasteam/steam/handlers/steamapps/SteamAppsTest.java
@@ -88,7 +88,9 @@ public class SteamAppsTest extends HandlerTestBase<SteamApps> {
 
     @Test
     public void picsGetProductInfo() {
-        JobID jobID = handler.picsGetProductInfo(440, 420);
+        PICSRequest app = new PICSRequest(440);
+        PICSRequest _package = new PICSRequest(420);
+        JobID jobID = handler.picsGetProductInfo(app, _package);
 
         ClientMsgProtobuf<CMsgClientPICSProductInfoRequest.Builder> msg = verifySend(EMsg.ClientPICSProductInfoRequest);
 


### PR DESCRIPTION
### Description
This PR does 2 things, 

1. Removes only_public from pics requests. From PR 911 on SteamKit.
2. `picsGetProductInfo()` is more aligned with SteamKit, needing `PICSRequest` to pass as arguments, consequently cleaning up multiple overloads of this method

Checks off 911 from #181 

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
