### PR TITLE
Support UTF-8 encoding

### DIFF
--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamapps/PICSProductInfo.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamapps/PICSProductInfo.java
@@ -10,6 +10,7 @@ import in.dragonbra.javasteam.util.stream.MemoryStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.Charset;
 
 /**
  * Represents the information for a single app or package
@@ -40,8 +41,14 @@ public class PICSProductInfo extends CallbackMsg {
 
         keyValues = new KeyValue();
         if (appInfo.hasBuffer() && !appInfo.getBuffer().isEmpty()) {
-            // we don't want to read the trailing null byte
-            try (MemoryStream ms = new MemoryStream(appInfo.getBuffer().toByteArray(), 0, appInfo.getBuffer().size() - 1)) {
+            try {
+                // get the buffer as a string using the jvm's default charset.
+                // note: IDK why, but we have to encode this using the default charset
+                String bufferString = appInfo.getBuffer().toString(Charset.defaultCharset());
+                // get the buffer as a byte array using utf-8 as a supported charset
+                byte[] byteBuffer = bufferString.getBytes("UTF-8");
+                // we don't want to read the trailing null byte
+                MemoryStream ms = new MemoryStream(byteBuffer, 0, byteBuffer.length - 1);
                 keyValues.readAsText(ms);
             } catch (IOException e) {
                 throw new IllegalArgumentException("failed to read buffer", e);

--- a/src/main/java/in/dragonbra/javasteam/types/KVTextReader.java
+++ b/src/main/java/in/dragonbra/javasteam/types/KVTextReader.java
@@ -3,6 +3,7 @@ package in.dragonbra.javasteam.types;
 import in.dragonbra.javasteam.util.Passable;
 import in.dragonbra.javasteam.util.Strings;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PushbackInputStream;
@@ -139,7 +140,7 @@ public class KVTextReader extends PushbackInputStream {
             // "
             read();
 
-            StringBuilder sb = new StringBuilder();
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
             while (!endOfStream()) {
                 if (peek() == '\\') {
@@ -152,7 +153,7 @@ public class KVTextReader extends PushbackInputStream {
                         replacedChar = escapedChar;
                     }
 
-                    sb.append(replacedChar);
+                    baos.write(replacedChar);
 
                     continue;
                 }
@@ -161,13 +162,14 @@ public class KVTextReader extends PushbackInputStream {
                     break;
                 }
 
-                sb.append((char) read());
+                baos.write(read());
             }
 
             // "
             read();
 
-            return sb.toString();
+            // convert the output stream as an utf-8 supported string.
+            return baos.toString("UTF-8");
         }
 
         if (next == '{' || next == '}') {


### PR DESCRIPTION
### Description
Getting app info from PICSProductInfo may contain symbols or foreign letters that were not being rendered correctly, either garbled text or question marks. 

We have to do a little converting getting the buffer from PICSProductInfo as UTF-8, but parsing it to KeyValues would break it again. 

KeyValues now stores parsed tokens into a ByteArrayOutputStream, once it's finished parsing the bytes, we convert it to a UTF-8 supported string. 

This brings back nearly all symbols and foreign letters, though there are a some characters still showing question marks. 

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
