### PR TITLE
Send guard duplicate request

### DIFF
--- a/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_1logon/SampleLogon.java
+++ b/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_1logon/SampleLogon.java
@@ -25,6 +25,11 @@ import in.dragonbra.javasteam.util.log.LogManager;
 // callback type to a function, whilst CallbackMgr routes the callback objects to the functions that
 // you have specified. a Callback<T> is bound to a specific callback manager.
 //
+// WARNING!
+// This the old login flow, we keep this sample around because it still currently works
+// for simple cases where you do not need to remember password.
+// See SampleLogonAuthentication for the new flow.
+//
 
 /**
  * @author lngtr


### PR DESCRIPTION
### Description
DuplicateRequest happens when accepting the prompt in the mobile app, and then trying to send guard code here, do not throw on it here because authentication will succeed on the next poll.

This makes it easier for users because even if 2FA code is asked, Steam will send a confirmation prompt to the app regardless.

From SteamKit PR 1212

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
