### PR TITLE
Port dependencies to Gradle Versions Catalog

### DIFF
--- a/.run/javasteam [build].run.xml
+++ b/.run/javasteam [build].run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="javasteam [build]" type="GradleRunConfiguration" factoryName="Gradle" nameIsGenerated="true">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="-x signMavenJavaPublication" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="build" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/javasteam [clean build].run.xml
+++ b/.run/javasteam [clean build].run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="javasteam [clean build]" type="GradleRunConfiguration" factoryName="Gradle" nameIsGenerated="true">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="-x signMavenJavaPublication" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="clean" />
+          <option value="build" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/javasteam [wrapper --gradle-version 8.4].run.xml
+++ b/.run/javasteam [wrapper --gradle-version 8.4].run.xml
@@ -1,0 +1,26 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="javasteam [wrapper --gradle-version 8.4]" type="GradleRunConfiguration" factoryName="Gradle" nameIsGenerated="true">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="wrapper" />
+          <option value="--gradle-version" />
+          <option value="8.4" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,11 @@
 //file:noinspection GroovyAssignabilityCheck
 
-// https://mvnrepository.com/artifact/io.github.gradle-nexus/publish-plugin
-// https://mvnrepository.com/artifact/com.google.protobuf/protobuf-gradle-plugin
 plugins {
-    id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
-    id 'com.google.protobuf' version "0.9.4"
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.maven.publishPlugin)
+    alias(libs.plugins.protobuf)
     id 'jacoco'
     id 'maven-publish'
-    id 'org.jetbrains.kotlin.jvm' version '1.9.0'
     id 'projectversiongen'
     id 'signing'
     id 'steamlanguagegen'
@@ -15,22 +13,20 @@ plugins {
 
 allprojects {
     group 'in.dragonbra'
-    version '1.3.0'
+    version libs.versions.javaSteam.get()
 }
 
-sourceCompatibility = 1.8
+sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
 
 repositories {
     mavenCentral()
 }
 
-// https://mvnrepository.com/artifact/com.google.protobuf/protoc
 protobuf.protoc {
-    artifact = 'com.google.protobuf:protoc:3.22.4'
+    artifact = libs.protoc.get()
 }
 
-// https://www.eclemma.org/jacoco
-jacoco.toolVersion = "0.8.10"
+jacoco.toolVersion = libs.versions.jacoco.get()
 
 jacocoTestReport.reports {
     xml.required = true
@@ -50,7 +46,7 @@ java {
     withJavadocJar()
 }
 
-// Note: Only allow junit 5
+// Only allow junit 5
 configurations {
     configureEach {
         exclude group: 'junit', module: 'junit'
@@ -71,44 +67,17 @@ compileJava.dependsOn(generateSteamLanguage)
 compileJava.dependsOn(generateProjectVersion)
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    implementation libs.commons.io
+    implementation libs.commons.lang3
+    implementation libs.commons.validator
+    implementation libs.gson
+    implementation libs.kotlin.coroutines
+    implementation libs.kotlin.stdib
+    implementation libs.okHttp
+    implementation libs.protobufJava
+    implementation libs.webSocket
 
-    // https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-core
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3'
-
-    // https://mvnrepository.com/artifact/com.google.code.gson/gson
-    implementation 'com.google.code.gson:gson:2.10.1'
-    // https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java
-    implementation 'com.google.protobuf:protobuf-java:3.22.4'
-    // https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp
-    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
-    // https://mvnrepository.com/artifact/commons-validator/commons-validator
-    implementation 'commons-validator:commons-validator:1.7'
-    // https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
-    implementation 'org.apache.commons:commons-lang3:3.12.0'
-    // https://mvnrepository.com/artifact/org.java-websocket/Java-WebSocket
-    implementation 'org.java-websocket:Java-WebSocket:1.5.4'
-    // https://mvnrepository.com/artifact/commons-io/commons-io
-    implementation 'commons-io:commons-io:2.13.0'
-
-    /* Unit Testing */
-
-    // https://mvnrepository.com/artifact/com.squareup.okhttp3/mockwebserver3-junit5
-    testImplementation 'com.squareup.okhttp3:mockwebserver3-junit5:5.0.0-alpha.11'
-    // https://mvnrepository.com/artifact/commons-codec/commons-codec
-    testImplementation 'commons-codec:commons-codec:1.16.0'
-    // https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.0'
-    // https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine
-    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
-    // https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on
-    testImplementation 'org.bouncycastle:bcprov-jdk15on:1.70'
-    // https://mvnrepository.com/artifact/org.mockito/mockito-core
-    testImplementation 'org.mockito:mockito-core:4.11.0'
-    // https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-params
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.0'
-    // https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter
-    testImplementation 'org.mockito:mockito-junit-jupiter:4.11.0'
+    testImplementation libs.bundles.testing
 }
 
 /* Artifact publishing */

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
-    alias(libs.plugins.maven.publishPlugin)
-    alias(libs.plugins.protobuf)
+    alias(libs.plugins.maven.publish)
+    alias(libs.plugins.protobuf.gradle)
     id 'jacoco'
     id 'maven-publish'
     id 'projectversiongen'
@@ -13,7 +13,7 @@ plugins {
 
 allprojects {
     group 'in.dragonbra'
-    version libs.versions.javaSteam.get()
+    version '1.3.0'
 }
 
 sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
@@ -54,7 +54,7 @@ configurations {
     }
 }
 
-// Note: builtBy() fixes gradle warning "Execution optimizations have been disabled for task"
+// builtBy() fixes gradle warning "Execution optimizations have been disabled for task"
 sourceSets.main {
     java.srcDirs(
             files("build/generated/source/steamd/main/java").builtBy(generateSteamLanguage),
@@ -74,7 +74,7 @@ dependencies {
     implementation libs.kotlin.coroutines
     implementation libs.kotlin.stdib
     implementation libs.okHttp
-    implementation libs.protobufJava
+    implementation libs.protobuf.java
     implementation libs.webSocket
 
     testImplementation libs.bundles.testing

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ repositories {
 }
 
 protobuf.protoc {
-    artifact = libs.protoc.get()
+    artifact = libs.protobuf.protoc.get()
 }
 
 jacoco.toolVersion = libs.versions.jacoco.get()

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     implementation localGroovy()
 
     // https://mvnrepository.com/artifact/commons-io/commons-io
-    implementation 'commons-io:commons-io:2.13.0'
+    implementation 'commons-io:commons-io:2.14.0'
 }
 
 gradlePlugin {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,7 @@
 [versions]
-# Java Steam version
-javaSteam = "1.3.0"
-
 # Java / Kotlin versions
 java = "1.8"
-kotlin = "1.9.0"
+kotlin = "1.9.10" # https://kotlinlang.org/docs/releases.html#release-details
 
 # Standard Library versions
 bouncyCastle = "1.70" # https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on
@@ -16,9 +13,8 @@ jacoco = "0.8.10" # https://www.eclemma.org/jacoco
 javaWebSocket = "1.5.4" # https://mvnrepository.com/artifact/org.java-websocket/Java-WebSocket
 kotlin-coroutines = "1.7.3" # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-core
 okHttp = "4.11.0" # https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp
-protobuf = "0.9.4" # https://mvnrepository.com/artifact/com.google.protobuf/protobuf-gradle-plugin
-protobufJava = "3.23.4" # https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java
-protoc = "3.23.4" # https://mvnrepository.com/artifact/com.google.protobuf/protoc
+protobuf = "3.23.4" # https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java
+protobuf-gradle = "0.9.4" # https://mvnrepository.com/artifact/com.google.protobuf/protobuf-gradle-plugin
 publishPlugin = "1.1.0" # https://mvnrepository.com/artifact/io.github.gradle-nexus/publish-plugin
 qrCode = "1.0.1" # https://mvnrepository.com/artifact/pro.leaco.qrcode/console-qrcode
 
@@ -37,32 +33,32 @@ gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlin-coroutines" }
 kotlin-stdib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 okHttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okHttp" }
-protobufJava = { module = "com.google.protobuf:protobuf-java", version.ref = "protobufJava" }
-protoc = { module = "com.google.protobuf:protoc", version.ref = "protoc" }
+protobuf-java = { module = "com.google.protobuf:protobuf-java", version.ref = "protobuf" }
+protoc = { module = "com.google.protobuf:protoc", version.ref = "protobuf" }
 qrCode = { module = "pro.leaco.qrcode:console-qrcode", version.ref = "qrCode" }
 webSocket = { module = "org.java-websocket:Java-WebSocket", version.ref = "javaWebSocket" }
 
-test-commonsCodec = { module = "commons-codec:commons-codec", version.ref = "commonsCodec" }
-test-jupiterApi = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "jupiterVersion" }
-test-jupiterEngine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "jupiterVersion" }
-test-jupiterParams = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "jupiterVersion" }
-test-mockitoCore = { module = "org.mockito:mockito-core", version.ref = "mockitoVersion" }
-test-mockitoJupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockitoVersion" }
-test-mockwebserver3 = { module = "com.squareup.okhttp3:mockwebserver3-junit5", version.ref = "mockWebServer" }
+test-commons-codec = { module = "commons-codec:commons-codec", version.ref = "commonsCodec" }
+test-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "jupiterVersion" }
+test-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "jupiterVersion" }
+test-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "jupiterVersion" }
+test-mock-webserver3 = { module = "com.squareup.okhttp3:mockwebserver3-junit5", version.ref = "mockWebServer" }
+test-mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockitoVersion" }
+test-mockito-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockitoVersion" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-maven-publishPlugin = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "publishPlugin" }
-protobuf = { id = "com.google.protobuf", version.ref = "protobuf" }
+maven-publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "publishPlugin" }
+protobuf-gradle = { id = "com.google.protobuf", version.ref = "protobuf-gradle" }
 
 [bundles]
 testing = [
     "bouncyCastle",
-    "test-commonsCodec",
-    "test-jupiterApi",
-    "test-jupiterEngine",
-    "test-jupiterParams",
-    "test-mockitoCore",
-    "test-mockitoJupiter",
-    "test-mockwebserver3"
+    "test-commons-codec",
+    "test-jupiter-api",
+    "test-jupiter-engine",
+    "test-jupiter-params",
+    "test-mockito-core",
+    "test-mockito-jupiter",
+    "test-mock-webserver3"
 ]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,68 @@
+[versions]
+# Java Steam version
+javaSteam = "1.3.0"
+
+# Java / Kotlin versions
+java = "1.8"
+kotlin = "1.9.0"
+
+# Standard Library versions
+bouncyCastle = "1.70" # https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on
+commons-io = "2.14.0" # https://mvnrepository.com/artifact/commons-io/commons-io
+commons-lang3 = "3.13.0" # https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
+commons-validator = "1.7" # https://mvnrepository.com/artifact/commons-validator/commons-validator
+gson = "2.10.1" # https://mvnrepository.com/artifact/com.google.code.gson/gson
+jacoco = "0.8.10" # https://www.eclemma.org/jacoco
+javaWebSocket = "1.5.4" # https://mvnrepository.com/artifact/org.java-websocket/Java-WebSocket
+kotlin-coroutines = "1.7.3" # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-core
+okHttp = "4.11.0" # https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp
+protobuf = "0.9.4" # https://mvnrepository.com/artifact/com.google.protobuf/protobuf-gradle-plugin
+protobufJava = "3.23.4" # https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java
+protoc = "3.23.4" # https://mvnrepository.com/artifact/com.google.protobuf/protoc
+publishPlugin = "1.1.0" # https://mvnrepository.com/artifact/io.github.gradle-nexus/publish-plugin
+qrCode = "1.0.1" # https://mvnrepository.com/artifact/pro.leaco.qrcode/console-qrcode
+
+# Testing Lib versions
+commonsCodec = "1.16.0" # https://mvnrepository.com/artifact/commons-codec/commons-codec
+jupiterVersion = "5.10.0" # https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api
+mockWebServer = "5.0.0-alpha.11" # https://mvnrepository.com/artifact/com.squareup.okhttp3/mockwebserver3-junit5
+mockitoVersion = "4.11.0" # https://mvnrepository.com/artifact/org.mockito/mockito-core
+
+[libraries]
+bouncyCastle = { module = "org.bouncycastle:bcprov-jdk15on", version.ref = "bouncyCastle" }
+commons-io = { module = "commons-io:commons-io", version.ref = "commons-io" }
+commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang3" }
+commons-validator = { module = "commons-validator:commons-validator", version.ref = "commons-validator" }
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
+kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlin-coroutines" }
+kotlin-stdib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
+okHttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okHttp" }
+protobufJava = { module = "com.google.protobuf:protobuf-java", version.ref = "protobufJava" }
+protoc = { module = "com.google.protobuf:protoc", version.ref = "protoc" }
+qrCode = { module = "pro.leaco.qrcode:console-qrcode", version.ref = "qrCode" }
+webSocket = { module = "org.java-websocket:Java-WebSocket", version.ref = "javaWebSocket" }
+
+test-commonsCodec = { module = "commons-codec:commons-codec", version.ref = "commonsCodec" }
+test-jupiterApi = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "jupiterVersion" }
+test-jupiterEngine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "jupiterVersion" }
+test-jupiterParams = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "jupiterVersion" }
+test-mockitoCore = { module = "org.mockito:mockito-core", version.ref = "mockitoVersion" }
+test-mockitoJupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockitoVersion" }
+test-mockwebserver3 = { module = "com.squareup.okhttp3:mockwebserver3-junit5", version.ref = "mockWebServer" }
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+maven-publishPlugin = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "publishPlugin" }
+protobuf = { id = "com.google.protobuf", version.ref = "protobuf" }
+
+[bundles]
+testing = [
+    "bouncyCastle",
+    "test-commonsCodec",
+    "test-jupiterApi",
+    "test-jupiterEngine",
+    "test-jupiterParams",
+    "test-mockitoCore",
+    "test-mockitoJupiter",
+    "test-mockwebserver3"
+]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", 
 kotlin-stdib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 okHttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okHttp" }
 protobuf-java = { module = "com.google.protobuf:protobuf-java", version.ref = "protobuf" }
-protoc = { module = "com.google.protobuf:protoc", version.ref = "protobuf" }
+protobuf-protoc = { module = "com.google.protobuf:protoc", version.ref = "protobuf" }
 qrCode = { module = "pro.leaco.qrcode:console-qrcode", version.ref = "qrCode" }
 webSocket = { module = "org.java-websocket:Java-WebSocket", version.ref = "javaWebSocket" }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/javasteam-samples/build.gradle
+++ b/javasteam-samples/build.gradle
@@ -14,8 +14,8 @@ dependencies {
     implementation libs.bouncyCastle
     implementation libs.gson
     implementation libs.kotlin.coroutines
-    implementation libs.protobufJava // To access protobufs directly as shown in Sample #2
+    implementation libs.protobuf.java // To access protobufs directly as shown in Sample #2
     implementation libs.qrCode
 
-    testImplementation libs.test.jupiterApi
+    testImplementation libs.test.jupiter.api
 }

--- a/javasteam-samples/build.gradle
+++ b/javasteam-samples/build.gradle
@@ -1,8 +1,8 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.9.0'
+    alias(libs.plugins.kotlin.jvm)
 }
 
-sourceCompatibility = 1.8
+sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
 
 repositories {
     mavenCentral()
@@ -11,22 +11,11 @@ repositories {
 dependencies {
     implementation rootProject
 
-    // https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-core
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3'
+    implementation libs.bouncyCastle
+    implementation libs.gson
+    implementation libs.kotlin.coroutines
+    implementation libs.protobufJava // To access protobufs directly as shown in Sample #2
+    implementation libs.qrCode
 
-    // https://mvnrepository.com/artifact/pro.leaco.qrcode/console-qrcode
-    implementation 'pro.leaco.qrcode:console-qrcode:1.0.1'
-
-    // https://mvnrepository.com/artifact/com.google.code.gson/gson
-    implementation 'com.google.code.gson:gson:2.10.1'
-
-    // https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on
-    implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
-
-    // To access protobufs directly as shown in Sample #2
-    // https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java
-    implementation 'com.google.protobuf:protobuf-java:3.22.4'
-
-    // https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.0'
+    testImplementation libs.test.jupiterApi
 }

--- a/javasteam-tf/build.gradle
+++ b/javasteam-tf/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 protobuf.protoc {
-    artifact = libs.protoc.get()
+    artifact = libs.protobuf.protoc.get()
 }
 
 javadoc {

--- a/javasteam-tf/build.gradle
+++ b/javasteam-tf/build.gradle
@@ -1,22 +1,21 @@
 //file:noinspection GroovyAssignabilityCheck
 
-// https://mvnrepository.com/artifact/com.google.protobuf/protobuf-gradle-plugin
 plugins {
-    id 'com.google.protobuf' version "0.9.4"
+    alias(libs.plugins.protobuf)
     id 'java'
     id 'maven-publish'
     id 'signing'
 }
 
-sourceCompatibility = 1.8
+sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
 
 repositories {
     mavenCentral()
 }
 
-// https://mvnrepository.com/artifact/com.google.protobuf/protoc
+//
 protobuf.protoc {
-    artifact = 'com.google.protobuf:protoc:3.23.4'
+    artifact = libs.protoc.get()
 }
 
 javadoc {
@@ -33,13 +32,9 @@ java {
 }
 
 dependencies {
-    // https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java
-    implementation 'com.google.protobuf:protobuf-java:3.23.4'
+    implementation libs.protobufJava
 
-    /* Unit Testing */
-
-    // https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.0'
+    testImplementation libs.test.jupiterApi
 }
 
 /* Artifact publishing */

--- a/javasteam-tf/build.gradle
+++ b/javasteam-tf/build.gradle
@@ -1,7 +1,7 @@
 //file:noinspection GroovyAssignabilityCheck
 
 plugins {
-    alias(libs.plugins.protobuf)
+    alias(libs.plugins.protobuf.gradle)
     id 'java'
     id 'maven-publish'
     id 'signing'
@@ -13,7 +13,6 @@ repositories {
     mavenCentral()
 }
 
-//
 protobuf.protoc {
     artifact = libs.protoc.get()
 }
@@ -22,19 +21,13 @@ javadoc {
     exclude "**/in/dragonbra/javasteam/protobufs/**"
 }
 
-test {
-    useJUnitPlatform()
-}
-
 java {
     withSourcesJar()
     withJavadocJar()
 }
 
 dependencies {
-    implementation libs.protobufJava
-
-    testImplementation libs.test.jupiterApi
+    implementation libs.protobuf.java
 }
 
 /* Artifact publishing */


### PR DESCRIPTION
### Description
Info: https://docs.gradle.org/current/userguide/platforms.html

Javasteam has multiple projects within it (main lib, samples, tf2) and each project shares some common dependencies between each other. Versions Catalogs help consolidate the dependencies into one location (minus buildSrc, it doesn't like it)

Port dependencies to Gradle Versions Catalogs.
Update gradle and dependencies
Add common gradle scripts

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
