### PR TITLE
Typo in JavaGen.writeSetterGetter

### DIFF
--- a/buildSrc/src/main/groovy/in/dragonbra/steamlanguagegen/generator/JavaGen.groovy
+++ b/buildSrc/src/main/groovy/in/dragonbra/steamlanguagegen/generator/JavaGen.groovy
@@ -325,7 +325,7 @@ class JavaGen implements Closeable, Flushable {
             writer.writeln '    return this.header;'
             writer.writeln '}'
             writer.writeln()
-            writer.writeln "public void getHeader($parentType header) {"
+            writer.writeln "public void setHeader($parentType header) {"
             writer.writeln '    this.header = header;'
             writer.writeln('}')
         }


### PR DESCRIPTION
### Description
Fixed a typo in JavaGen.writeSetterGetter. 

Closes: #227 
### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
