### PR TITLE
Deprecate WebAPIUserNonce in logon, and MachineAuth callback

### DIFF
--- a/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_5steamguard/SampleSteamGuardRememberMe.java
+++ b/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_5steamguard/SampleSteamGuardRememberMe.java
@@ -57,6 +57,11 @@ import java.util.Scanner;
 // 2. logon to account using username, password, and sha-1 hash of the sentry file
 
 /**
+ * This sample is obsolete. Check out
+ * {@link in.dragonbra.javasteamsamples._1logon.SampleLogonAuthentication }
+ * and {@link in.dragonbra.javasteamsamples._1logon.SampleLogonQRAuthentication}
+ * Reference: <a href="https://github.com/SteamRE/SteamKit/pull/1270#issuecomment-1768359942">SteamKit issue</a>
+ *
  * @author lngtr
  * @since 2018-02-28
  */

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamuser/MachineAuthDetails.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamuser/MachineAuthDetails.java
@@ -6,8 +6,11 @@ import in.dragonbra.javasteam.steam.steamclient.callbackmgr.Callback;
 import in.dragonbra.javasteam.types.JobID;
 
 /**
+ * @deprecated Steam no longer sends machine auth as of 2023, use SteamAuthentication.
+ *
  * Represents details required to complete a machine auth request.
  */
+@Deprecated
 public class MachineAuthDetails {
 
     private JobID jobID;

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamuser/SteamUser.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamuser/SteamUser.java
@@ -231,7 +231,9 @@ public class SteamUser extends ClientMsgHandler {
      * This should normally be used in response to a {@link UpdateMachineAuthCallback}.
      *
      * @param details The details pertaining to the response.
+     * @deprecated Steam no longer sends machine auth as of 2023, use SteamAuthentication.
      */
+    @Deprecated
     public void sendMachineAuthResponse(MachineAuthDetails details) {
         if (details == null) {
             throw new IllegalArgumentException("details is null");

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamuser/callback/LoggedOnCallback.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamuser/callback/LoggedOnCallback.java
@@ -46,6 +46,7 @@ public class LoggedOnCallback extends CallbackMsg {
 
     private byte[] steam2Ticket;
 
+    @Deprecated
     private String webAPIUserNonce;
 
     private String ipCountryCode;
@@ -204,8 +205,10 @@ public class LoggedOnCallback extends CallbackMsg {
     }
 
     /**
+     * @deprecated Steam no longer sends webapi nonce as of October 2023, use SteamAuthentication.
      * @return the WebAPI authentication user nonce.
      */
+    @Deprecated
     public String getWebAPIUserNonce() {
         return webAPIUserNonce;
     }


### PR DESCRIPTION
### Description
Annotate some more deprecations in favor of the new Login Flow system

Checks off PR 1270 in #181 
See PR 1270 over at SteamKit

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
