### PR TITLE
Update Github workflow

### DIFF
--- a/.github/workflows/javasteam-build-pr.yml
+++ b/.github/workflows/javasteam-build-pr.yml
@@ -6,11 +6,9 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
 # Artifacts: https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts
 
-name: Java CI/CD
+name: Java PR CI/CD
 
 on:
-  push:
-    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 
@@ -34,7 +32,3 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: build -x signMavenJavaPublication
-      - uses: actions/upload-artifact@v3
-        with:
-          name: JavaSteam
-          path: build/libs

--- a/.github/workflows/javasteam-build-push.yml
+++ b/.github/workflows/javasteam-build-push.yml
@@ -1,0 +1,39 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+# Artifacts: https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts
+
+name: Java Push CI/CD
+
+on:
+  push:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Checkout JavaSteam with Java 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Build with Gradle, skip signing
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build -x signMavenJavaPublication
+      - uses: actions/upload-artifact@v3
+        if: github.event_name != 'pull_request'
+        with:
+          name: JavaSteam
+          path: build/libs

--- a/.github/workflows/javasteam-build-push.yml
+++ b/.github/workflows/javasteam-build-push.yml
@@ -33,7 +33,6 @@ jobs:
         with:
           arguments: build -x signMavenJavaPublication
       - uses: actions/upload-artifact@v3
-        if: github.event_name != 'pull_request'
         with:
           name: JavaSteam
           path: build/libs

--- a/.github/workflows/javasteam-build.yml
+++ b/.github/workflows/javasteam-build.yml
@@ -4,6 +4,7 @@
 # documentation.
 # This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+# Artifacts: https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts
 
 name: Java CI/CD
 
@@ -21,25 +22,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout JavaSteam
-      uses: actions/checkout@v3
-    
-    - name: Set up JDK 8
-      uses: actions/setup-java@v3
-      with:
-        java-version: '8'
-        distribution: 'temurin'
-
-    # This could also be done in gradle.properties: org.gradle.jvmargs=-Xmx8G
-    - name: Increase gradle daemon heap size
-      run: |
-        sed -i "s/org.gradle.jvmargs=/org.gradle.jvmargs=-Xmx4g /" gradle.properties
-
-    - name: Validate Gradle wrapper
-      uses: gradle/wrapper-validation-action@v1
-
-    - name: Build with Gradle, skip signing
-      uses: gradle/gradle-build-action@v2
-      with:
-        arguments: build -x signMavenJavaPublication
-
+      - uses: actions/checkout@v4
+      - name: Checkout JavaSteam with Java 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Build with Gradle, skip signing
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build -x signMavenJavaPublication
+      - uses: actions/upload-artifact@v3
+        with:
+          name: JavaSteam
+          path: build/libs

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ javadoc {
 
 test {
     useJUnitPlatform()
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
 }
 
 java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ signing.secretKeyRingFile=~/.gnupg/secring.gpg
 ossrhUsername=
 ossrhPassword=
 
-org.gradle.jvmargs=-Xmx1024m
+org.gradle.jvmargs=-Xmx2048m


### PR DESCRIPTION
### Description
Checking off another security advisory.

- Allow JUnit test results to be outputted into the build log (pass, fail, and skip)
- Update our CI/CD workflow
- Add artifact uploading 

Also trying out updating jvmargs in gradle.properties, hopefully this can succeed in removing the workflow hack to stop daemon exhaustion when building in workflow.

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
