### PR TITLE
Change runWaitAllCallbacks parameter from int to long.

### DIFF
--- a/src/main/java/in/dragonbra/javasteam/steam/steamclient/callbackmgr/CallbackManager.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/steamclient/callbackmgr/CallbackManager.java
@@ -77,7 +77,7 @@ public class CallbackManager implements ICallbackMgrInternals {
      *
      * @param timeout The length of time to block.
      */
-    public void runWaitAllCallbacks(int timeout) {
+    public void runWaitAllCallbacks(long timeout) {
         List<ICallbackMsg> calls = steamClient.getAllCallbacks(true, timeout);
         for (ICallbackMsg call : calls) {
             handle(call);

--- a/src/test/java/in/dragonbra/javasteam/steam/steamclient/callbackmgr/CallbackManagerTest.java
+++ b/src/test/java/in/dragonbra/javasteam/steam/steamclient/callbackmgr/CallbackManagerTest.java
@@ -189,10 +189,10 @@ public class CallbackManagerTest extends TestBase {
                 client.postCallback(callback);
             }
 
-            mgr.runWaitAllCallbacks(1);
+            mgr.runWaitAllCallbacks(1000L);
             assertEquals(10, numCallbacksRun[0]);
 
-            mgr.runWaitAllCallbacks(1);
+            mgr.runWaitAllCallbacks(1000L);
             assertEquals(10, numCallbacksRun[0]);
         } catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION


### Description
`steamClient.getAllCallbacks(...)` accepts a long, so this should be more consistent.

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
