### PR TITLE
Post release fixes

### DIFF
--- a/.github/workflows/javasteam-build-pr.yml
+++ b/.github/workflows/javasteam-build-pr.yml
@@ -11,6 +11,9 @@ name: Java PR CI/CD
 on:
   pull_request:
     branches: [ "master" ]
+    paths-ignore:
+      - '**.md'
+      - 'tools/**'
 
 permissions:
   contents: read

--- a/.github/workflows/javasteam-build-push.yml
+++ b/.github/workflows/javasteam-build-push.yml
@@ -11,6 +11,9 @@ name: Java Push CI/CD
 on:
   push:
     branches: [ "master" ]
+    paths-ignore:
+      - '**.md'
+      - 'tools/**'
 
 permissions:
   contents: read

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamuser/LogOnDetails.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamuser/LogOnDetails.java
@@ -1,6 +1,7 @@
 package in.dragonbra.javasteam.steam.handlers.steamuser;
 
 import in.dragonbra.javasteam.enums.EOSType;
+import in.dragonbra.javasteam.steam.authentication.AuthPollResult;
 import in.dragonbra.javasteam.steam.authentication.SteamAuthentication;
 import in.dragonbra.javasteam.types.SteamID;
 import in.dragonbra.javasteam.util.Utils;
@@ -169,7 +170,7 @@ public class LogOnDetails {
 
     /**
      * Gets the 'Should Remember Password' flag.
-     * This is used in combination with the <see cref="AccessToken"/> for password-less login.
+     * This is used in combination with the {@link AuthPollResult#getAccessToken()} for password-less login.
      *
      * @return the 'Should Remember Password' flag.
      */


### PR DESCRIPTION
### Description
Dokka doesn't properly hook into the publishing process making closing a new version fail because there is no java doc. We'll make it into an artifact until Dokka gets refactored. (I believe Dokka issue 3132 would fix this)

No need to run CI for markdown changes. Also included `/tools` to be ignored too. 

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
