### PR TITLE
Remove spongycastle

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,16 +44,14 @@ Maven
 </dependency>
 ```
 
-**3. Add the appropriate cryptography dependency to your project. JavaSteam depends on this.**
+**3. Add the cryptography dependency to your project. JavaSteam depends on this.**
 
-[Android | Spongy Castle](https://mvnrepository.com/artifact/com.madgag.spongycastle/prov)
-
-[Non-Android | Bouncy Castle](https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk18on)
+[Bouncy Castle](https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk18on)
 
 
 ## Getting Started
 
-You can head to the very short [Getting Started](https://github.com/Longi94/JavaSteam/wiki/Getting-started) page or take a look at the [samples](https://github.com/Longi94/JavaSteam/tree/master/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples) to get you started with using this library. 
+You can head to the very short [Getting Started](https://github.com/Longi94/JavaSteam/wiki/Getting-started) page or take a look at the [samples](https://github.com/Longi94/JavaSteam/tree/master/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples) to get you started with using this library.
 
 There some [open-source projects](https://github.com/Longi94/JavaSteam/wiki/Samples) too you can check out.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,7 +69,7 @@ tasks.dokkaJavadoc {
     }
 }
 
-// Make sure Maven Publishing gets javadock
+// Make sure Maven Publishing gets javadoc
 // https://stackoverflow.com/a/71172854
 lateinit var javadocArtifact: PublishArtifact
 tasks {
@@ -108,12 +108,10 @@ sourceSets.main {
 tasks["lintKotlinMain"].dependsOn("formatKotlin")
 tasks["check"].dependsOn("jacocoTestReport")
 tasks["compileJava"].dependsOn("generateSteamLanguage", "generateProjectVersion", "generateRpcMethods")
-// tasks["build"].finalizedBy(dokkaJavadocJar)
 
 dependencies {
     implementation(libs.commons.io)
     implementation(libs.commons.lang3)
-    implementation(libs.commons.validator)
     implementation(libs.gson)
     implementation(libs.kotlin.coroutines)
     implementation(libs.kotlin.stdib)
@@ -145,12 +143,12 @@ publishing {
                 scm {
                     connection = "scm:git:git://github.com/Longi94/JavaSteam.git"
                     developerConnection = "scm:git:ssh://github.com:Longi94/JavaSteam.git"
-                    url = "http://github.com/Longi94/JavaSteam/tree/master"
+                    url = "https://github.com/Longi94/JavaSteam/tree/master"
                 }
                 licenses {
                     license {
                         name = "MIT License"
-                        url = "http://www.opensource.org/licenses/mit-license.php"
+                        url = "https://www.opensource.org/licenses/mit-license.php"
                     }
                 }
                 developers {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 
 allprojects {
     group = "in.dragonbra"
-    version = "1.4.0"
+    version = "1.4.1-SNAPSHOT"
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,6 @@ kotlinter = "4.3.0" # https://plugins.gradle.org/plugin/org.jmailen.kotlinter
 bouncyCastle = "1.78" # https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk18on
 commons-io = "2.16.0" # https://mvnrepository.com/artifact/commons-io/commons-io
 commons-lang3 = "3.14.0" # https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
-commons-validator = "1.8.0" # https://mvnrepository.com/artifact/commons-validator/commons-validator
 gson = "2.10.1" # https://mvnrepository.com/artifact/com.google.code.gson/gson
 jacoco = "0.8.12" # https://www.eclemma.org/jacoco
 javaWebSocket = "1.5.6" # https://mvnrepository.com/artifact/org.java-websocket/Java-WebSocket
@@ -35,7 +34,6 @@ mockitoVersion = "5.11.0" # https://mvnrepository.com/artifact/org.mockito/mocki
 bouncyCastle = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncyCastle" }
 commons-io = { module = "commons-io:commons-io", version.ref = "commons-io" }
 commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang3" }
-commons-validator = { module = "commons-validator:commons-validator", version.ref = "commons-validator" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlin-coroutines" }
 kotlin-stdib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }

--- a/src/main/java/in/dragonbra/javasteam/steam/authentication/SteamAuthentication.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/authentication/SteamAuthentication.kt
@@ -16,6 +16,7 @@ import `in`.dragonbra.javasteam.rpc.service.Authentication
 import `in`.dragonbra.javasteam.steam.handlers.steamunifiedmessages.SteamUnifiedMessages
 import `in`.dragonbra.javasteam.steam.steamclient.SteamClient
 import `in`.dragonbra.javasteam.types.SteamID
+import `in`.dragonbra.javasteam.util.crypto.CryptoHelper
 import java.math.BigInteger
 import java.nio.charset.StandardCharsets
 import java.security.KeyFactory
@@ -159,7 +160,7 @@ class SteamAuthentication(private val steamClient: SteamClient, unifiedMessages:
         val rsaPublicKeySpec = RSAPublicKeySpec(publicModulus, publicExponent)
         val publicKey = KeyFactory.getInstance("RSA").generatePublic(rsaPublicKeySpec)
 
-        val cipher = Cipher.getInstance("RSA/None/PKCS1Padding").apply {
+        val cipher = Cipher.getInstance("RSA/None/PKCS1Padding", CryptoHelper.SEC_PROV).apply {
             init(Cipher.ENCRYPT_MODE, publicKey)
         }
 

--- a/src/main/java/in/dragonbra/javasteam/util/NetHelpers.java
+++ b/src/main/java/in/dragonbra/javasteam/util/NetHelpers.java
@@ -1,17 +1,22 @@
 package in.dragonbra.javasteam.util;
 
-import org.apache.commons.validator.routines.InetAddressValidator;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author lngtr
  * @since 2018-02-22
  */
 public class NetHelpers {
+
+    private static final String IPV4_REGEX = "^((25[0-5]|2[0-4]\\d|[01]?\\d\\d?)\\.){3}(25[0-5]|2[0-4]\\d|[01]?\\d\\d?)$";
+
+    private static final Pattern pattern = Pattern.compile(IPV4_REGEX);
 
     public static InetAddress getIPAddress(int ipAddr) {
         ByteBuffer b = ByteBuffer.allocate(4);
@@ -39,7 +44,9 @@ public class NetHelpers {
 
         String[] split = address.split(":");
 
-        if (!InetAddressValidator.getInstance().isValidInet4Address(split[0])) {
+        Matcher matcher = pattern.matcher(split[0]);
+
+        if (!matcher.matches()) {
             return null;
         }
 

--- a/src/main/java/in/dragonbra/javasteam/util/crypto/CryptoHelper.java
+++ b/src/main/java/in/dragonbra/javasteam/util/crypto/CryptoHelper.java
@@ -31,17 +31,10 @@ public class CryptoHelper {
 
     static {
         try {
-            if (Utils.getOSType() == EOSType.AndroidUnknown) {
-                Class<? extends Provider> provider =
-                        (Class<? extends Provider>) Class.forName("org.spongycastle.jce.provider.BouncyCastleProvider");
-                Security.insertProviderAt(provider.getDeclaredConstructor().newInstance(), 1);
-                SEC_PROV = "SC";
-            } else {
-                Class<? extends Provider> provider =
-                        (Class<? extends Provider>) Class.forName("org.bouncycastle.jce.provider.BouncyCastleProvider");
-                Security.addProvider(provider.getDeclaredConstructor().newInstance());
-                SEC_PROV = "BC";
-            }
+            Class<? extends Provider> provider =
+                    (Class<? extends Provider>) Class.forName("org.bouncycastle.jce.provider.BouncyCastleProvider");
+            Security.addProvider(provider.getDeclaredConstructor().newInstance());
+            SEC_PROV = "BC";
         } catch (Exception e) {
             throw new SecurityException("Couldn't create security provider", e);
         }


### PR DESCRIPTION
### Description
Songy Castle is _old_ and hasn't been updated since 2017. There could be a risk for security issues using it, though I am no expert with the _Castles_ to know how much integration is there just for a Cipher instance. 

This was a legacy support Android API running lower than Honeycomb. Google has since renamed their BC package since(even though that is now deprecated too). 

Using normal BouncyCastle for Android is recommended based on many discussions whille reseaching. Even android development has a support floor for API 21 (API 24 is starting to become the new floor too with some dependencies).

See: https://stackoverflow.com/a/66323575/13225929

This [wiki page](https://github.com/Longi94/JavaSteam/wiki/Download) should be updated to reflect the current info from the main readme. 

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary

Addtional: 
- [x] Successul login via Android
