### PR TITLE
Correct ChatMode value

### DIFF
--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamuser/ChatMode.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamuser/ChatMode.kt
@@ -13,5 +13,5 @@ enum class ChatMode(val mode: Int) {
     /**
      * The chat mode for new Steam group chat.
      */
-    NEW_STEAM_CHAT(1),
+    NEW_STEAM_CHAT(2),
 }

--- a/src/test/java/in/dragonbra/javasteam/steam/handlers/steamuser/SteamUserTest.java
+++ b/src/test/java/in/dragonbra/javasteam/steam/handlers/steamuser/SteamUserTest.java
@@ -11,6 +11,7 @@ import in.dragonbra.javasteam.protobufs.steamclient.SteammessagesClientserverLog
 import in.dragonbra.javasteam.steam.handlers.HandlerTestBase;
 import in.dragonbra.javasteam.steam.handlers.steamuser.callback.*;
 import in.dragonbra.javasteam.types.SteamID;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -213,5 +214,11 @@ public class SteamUserTest extends HandlerTestBase<SteamUser> {
 
         assertEquals(new Date(1521763200000L), callback.getUpdateTime());
         assertEquals(7, callback.getMessages().size());
+    }
+
+    @Test
+    public void verifyChatModeValues() {
+        Assertions.assertEquals(0, ChatMode.DEFAULT.getMode());
+        Assertions.assertEquals(2, ChatMode.NEW_STEAM_CHAT.getMode());
     }
 }


### PR DESCRIPTION
### Description
ChatMode.NEW_STEAM_CHAT's value is actually 2 to utilize the new unified chat features. 

Current Work around is to send a protobuf to steam to enable this feature, usually during or after `LoggedOnCallback` callback.
```java
 var uiMode = new ClientMsgProtobuf<SteammessagesClientserver2.CMsgClientUIMode.Builder>(
         SteammessagesClientserver2.CMsgClientUIMode.class,
         EMsg.ClientCurrentUIMode
 );
 uiMode.getBody().setChatMode(2);
 steamClient.send(uiMode);
```

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
