### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/javasteam-build-pr.yml
+++ b/.github/workflows/javasteam-build-pr.yml
@@ -26,13 +26,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Checkout JavaSteam with Java 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'temurin'
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v2
+        uses: gradle/actions/wrapper-validation@v3
       - name: Build with Gradle, skip signing
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: build -x signMavenJavaPublication

--- a/.github/workflows/javasteam-build-push.yml
+++ b/.github/workflows/javasteam-build-push.yml
@@ -25,17 +25,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Checkout JavaSteam with Java 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'temurin'
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v2
+        uses: gradle/actions/wrapper-validation@v3
       - name: Build with Gradle, skip signing
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: build -x signMavenJavaPublication
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: JavaSteam
           path: build/libs


### PR DESCRIPTION
### Description
Pushing recent changes made the workflow fail with a weird error

```
Run gradle/wrapper-validation-action@v2
Error: Multiple errors returned
Error: Error 0: connect ETIMEDOUT 104.16.72.101:443
Error: Error 1: connect ENETUNREACH 2606:4700::6[8](https://github.com/Longi94/JavaSteam/actions/runs/11113054661/job/30876506783#step:4:9)10:4965:443 - Local (:::0)
Error: Error 2: connect ETIMEDOUT 104.16.73.101:443
Error: Error 3: connect ENETUNREACH 2606:4700::68[10](https://github.com/Longi94/JavaSteam/actions/runs/11113054661/job/30876506783#step:4:11):4865:443 - Local (:::0)
```
But some of the actions are out of date with some of them having deprecation dates at the tail end of this year. So let's update our workflows and see if that fixes it. 🥲 

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
