### PR TITLE
Stop ktlint (kotlinter) from changing line separators

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,8 +5,6 @@ charset = utf-8
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-end_of_line = lf
-
 [*.{kt,kts}]
 ij_kotlin_packages_to_use_import_on_demand = java.util.**, in.dragonbra.javasteam.protobufs.steamclient.**, kotlinx.coroutines.**
 indent_size = 4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,29 @@ repositories {
     mavenCentral()
 }
 
+// TODO remove (all this) once kotlinter supports ktlint 1.3.2+ once that's released.
+buildscript {
+    configurations.classpath {
+        resolutionStrategy {
+            repositories {
+                maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
+            }
+            force(
+                "com.pinterest.ktlint:ktlint-cli-reporter-checkstyle:1.4.0-SNAPSHOT",
+                "com.pinterest.ktlint:ktlint-cli-reporter-core:1.4.0-SNAPSHOT",
+                "com.pinterest.ktlint:ktlint-cli-reporter-html:1.4.0-SNAPSHOT",
+                "com.pinterest.ktlint:ktlint-cli-reporter-json:1.4.0-SNAPSHOT",
+                "com.pinterest.ktlint:ktlint-cli-reporter-plain:1.4.0-SNAPSHOT",
+                "com.pinterest.ktlint:ktlint-cli-reporter-sarif:1.4.0-SNAPSHOT",
+                "com.pinterest.ktlint:ktlint-rule-engine-core:1.4.0-SNAPSHOT",
+                "com.pinterest.ktlint:ktlint-rule-engine:1.4.0-SNAPSHOT",
+                "com.pinterest.ktlint:ktlint-ruleset-standard:1.4.0-SNAPSHOT"
+            )
+        }
+    }
+}
+// end to-do
+
 java {
     sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
     targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())


### PR DESCRIPTION
### Description
Checking out files on windows creates the files as crlf, and editorconfig didnt so anything when changing the `end_of_line` field. So no matter what, building always changed kt files back to lf, creating (many) useless files staged for commit. 

pinterest/ktlint issue 2747

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
