### PR TITLE
Add KV alternate end and basic test.

### DIFF
--- a/src/main/java/in/dragonbra/javasteam/types/KeyValue.java
+++ b/src/main/java/in/dragonbra/javasteam/types/KeyValue.java
@@ -624,7 +624,7 @@ public class KeyValue {
         while (true) {
             Type type = Type.from(br.readByte());
 
-            if (type == Type.END) {
+            if (type == Type.END || type == Type.ALTERNATEEND) {
                 break;
             }
 
@@ -685,7 +685,8 @@ public class KeyValue {
         COLOR((byte) 6),
         UINT64((byte) 7),
         END((byte) 8),
-        INT64((byte) 10);
+        INT64((byte) 10),
+        ALTERNATEEND((byte) 11);
 
         private final byte code;
 

--- a/src/test/java/in/dragonbra/javasteam/types/KeyValueTest.java
+++ b/src/test/java/in/dragonbra/javasteam/types/KeyValueTest.java
@@ -551,6 +551,27 @@ public class KeyValueTest extends TestBase {
     }
 
     @Test
+    public void decodesBinaryWithAlternateEnd() {
+        var hex = "00546573744F626A656374000A6B65790001020304050607080B0B";
+        byte[] binary = null;
+        try {
+            binary = Hex.decodeHex(hex);
+        } catch (DecoderException e) {
+            Assertions.fail(e);
+        }
+        var kv = new KeyValue();
+
+        try (var ms = new MemoryStream(binary)) {
+            var read = kv.tryReadAsBinary(ms);
+            Assertions.assertTrue(read);
+        } catch (IOException e) {
+            Assertions.fail(e);
+        }
+
+        Assertions.assertEquals(0x0807060504030201L, kv.get("key").asLong());
+    }
+
+    @Test
     public void keyValuesHandlesEnum() {
         KeyValue kv = KeyValue.loadFromString("" +
                 "\"root\"" +


### PR DESCRIPTION
### Description
- Add support for 0x0B (AlternateEnd) to KeyValue
- Add basic support test case. 

Checks off `Commit 76163ad7998f20674ba024db54679e660f62e7ab` in #181 

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
