### PR TITLE
Build functionality for the server list to refresh itself

### DIFF
--- a/src/main/java/in/dragonbra/javasteam/networking/steam3/UdpConnection.java
+++ b/src/main/java/in/dragonbra/javasteam/networking/steam3/UdpConnection.java
@@ -356,7 +356,7 @@ public class UdpConnection extends Connection {
 
         byte[] data = baos.toByteArray();
 
-        logger.debug("Dispatchin message: " + data.length + " bytes");
+        logger.debug("Dispatching message: " + data.length + " bytes");
 
         onNetMsgReceived(new NetMsgEventArgs(data, currentEndPoint));
 

--- a/src/main/java/in/dragonbra/javasteam/networking/steam3/UdpConnection.java
+++ b/src/main/java/in/dragonbra/javasteam/networking/steam3/UdpConnection.java
@@ -548,7 +548,7 @@ public class UdpConnection extends Connection {
                     while (received) {
 
                         // Ignore packets that aren't sent by the server we're connected to.
-                        if (!packet.getAddress().equals(currentEndPoint.getAddress()) && packet.getPort() != packet.getPort()) {
+                        if (!packet.getAddress().equals(currentEndPoint.getAddress()) && packet.getPort() != currentEndPoint.getPort()) {
                             continue;
                         }
 

--- a/src/main/java/in/dragonbra/javasteam/steam/CMClient.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/CMClient.java
@@ -8,7 +8,6 @@ import in.dragonbra.javasteam.generated.MsgClientLogon;
 import in.dragonbra.javasteam.generated.MsgClientServerUnavailable;
 import in.dragonbra.javasteam.networking.steam3.*;
 import in.dragonbra.javasteam.protobufs.steamclient.SteammessagesBase.CMsgMulti;
-import in.dragonbra.javasteam.protobufs.steamclient.SteammessagesClientserver.CMsgClientCMList;
 import in.dragonbra.javasteam.protobufs.steamclient.SteammessagesClientserver.CMsgClientSessionToken;
 import in.dragonbra.javasteam.protobufs.steamclient.SteammessagesClientserverLogin.CMsgClientHello;
 import in.dragonbra.javasteam.protobufs.steamclient.SteammessagesClientserverLogin.CMsgClientHeartBeat;
@@ -21,8 +20,8 @@ import in.dragonbra.javasteam.steam.steamclient.configuration.SteamConfiguration
 import in.dragonbra.javasteam.types.SteamID;
 import in.dragonbra.javasteam.util.IDebugNetworkListener;
 import in.dragonbra.javasteam.util.MsgUtil;
-import in.dragonbra.javasteam.util.NetHelpers;
 import in.dragonbra.javasteam.util.NetHookNetworkListener;
+import in.dragonbra.javasteam.util.Strings;
 import in.dragonbra.javasteam.util.event.EventArgs;
 import in.dragonbra.javasteam.util.event.EventHandler;
 import in.dragonbra.javasteam.util.event.ScheduledFunction;
@@ -294,7 +293,7 @@ public abstract class CMClient {
 
     public static IPacketMsg getPacketMsg(byte[] data) {
         if (data.length < 4) {
-            logger.debug("PacketMsg too small to contain a message, was only {0} bytes. Message: 0x{1}");
+            logger.debug("PacketMsg too small to contain a message, was only " + data.length + " bytes. Message: " + Strings.toHex(data));
             return null;
         }
 
@@ -321,6 +320,7 @@ public abstract class CMClient {
 
         try {
             if (MsgUtil.isProtoBuf(rawEMsg)) {
+                // if the emsg is flagged, we're a proto message
                 return new PacketClientMsgProtobuf(eMsg, data);
             } else {
                 return new PacketClientMsg(eMsg, data);

--- a/src/main/java/in/dragonbra/javasteam/steam/discovery/IServerListProvider.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/discovery/IServerListProvider.kt
@@ -1,9 +1,18 @@
 package `in`.dragonbra.javasteam.steam.discovery
 
+import java.time.Instant
+
 /**
  * An interface for persisting the server list for connection discovery
  */
 interface IServerListProvider {
+
+    /**
+     * When the server list was last refreshed, used to determine if the server list should be refreshed from the Steam Directory
+     * This should return DateTime with the UTC kind
+     */
+    val lastServerListRefresh: Instant
+
     /**
      * Ask a provider to fetch any servers that it has available
      * @return A list of IPEndPoints representing servers

--- a/src/main/java/in/dragonbra/javasteam/steam/discovery/MemoryServerListProvider.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/discovery/MemoryServerListProvider.kt
@@ -1,11 +1,20 @@
 package `in`.dragonbra.javasteam.steam.discovery
 
+import java.time.Instant
+
 /**
  * A server list provider that uses an in-memory list
  */
 class MemoryServerListProvider : IServerListProvider {
 
-    var servers: List<ServerRecord> = listOf()
+    private var servers: List<ServerRecord> = listOf()
+    private var lastUpdated: Instant = Instant.MIN
+
+    /**
+     * Returns the last time the server list was updated
+     */
+    override val lastServerListRefresh: Instant
+        get() = lastUpdated
 
     /**
      * Returns the stored server list in memory
@@ -19,5 +28,6 @@ class MemoryServerListProvider : IServerListProvider {
      */
     override fun updateServerList(endpoints: List<ServerRecord>) {
         servers = endpoints
+        lastUpdated = Instant.now()
     }
 }

--- a/src/main/java/in/dragonbra/javasteam/steam/discovery/NullServerListProvider.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/discovery/NullServerListProvider.kt
@@ -1,5 +1,7 @@
 package `in`.dragonbra.javasteam.steam.discovery
 
+import java.time.Instant
+
 /**
  * @author lngtr
  * @since 2018-02-20
@@ -10,10 +12,16 @@ package `in`.dragonbra.javasteam.steam.discovery
 class NullServerListProvider : IServerListProvider {
 
     /**
+     * Always returns [Instant.MIN]
+     */
+    override val lastServerListRefresh: Instant
+        get() = Instant.MIN
+
+    /**
      * No-op implementation that returns an empty server list
      * @return an Empty server list
      */
-    override fun fetchServerList(): List<ServerRecord> = emptyList<ServerRecord>()
+    override fun fetchServerList(): List<ServerRecord> = emptyList()
 
     /**
      * No-op implementation that does not persist server list

--- a/src/main/java/in/dragonbra/javasteam/steam/discovery/SmartCMServerList.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/discovery/SmartCMServerList.kt
@@ -17,44 +17,127 @@ import java.util.EnumSet
 @Suppress("unused")
 class SmartCMServerList(private val configuration: SteamConfiguration) {
 
-    private val servers: MutableList<ServerInfo> = mutableListOf()
+    companion object {
+        private val logger: Logger = LogManager.getLogger(SmartCMServerList::class.java)
 
-    // Determines how long a server's bad connection state is remembered for.
+        /**
+         * The default fallback Websockets server to attempt connecting to if fetching server list through other means fails.
+         * If the default server set here no longer works, please create a pull request to update it or file an issue.
+         * [Issue Tracker](https://github.com/Longi94/JavaSteam/issues)
+         */
+        @JvmStatic
+        var defaultServerWebSocket = "cmp1-sea1.steamserver.net:443"
+
+        /**
+         * The default fallback TCP/UDP server to attempt connecting to if fetching server list through other means fails.
+         * If the default server set here no longer works, please create a pull request to update it or file an issue.
+         * [Issue Tracker](https://github.com/Longi94/JavaSteam/issues)
+         */
+        @JvmStatic
+        var defaultServerNetFilter = "ext1-sea1.steamserver.net:27017"
+    }
+
+    private val servers: MutableList<ServerInfo> = mutableListOf()
+    private var serversLastRefresh: Instant = Instant.MIN
+
+    /**
+     * Determines how long the server list cache is used as-is before attempting to refresh from the Steam Directory.
+     */
+    @Suppress("MemberVisibilityCanBePrivate")
+    var serverListBeforeRefreshTimeSpan: Duration = Duration.ofDays(7)
+
+    /**
+     * Determines how long a server's bad connection state is remembered for.
+     */
     @Suppress("MemberVisibilityCanBePrivate")
     var badConnectionMemoryTimeSpan: Duration = Duration.ofMinutes(5)
 
     @Throws(IOException::class)
     private fun startFetchingServers() {
-        // if the server list has been populated, no need to perform any additional work
         if (servers.isNotEmpty()) {
-            return
+            // if the server list has been populated, no need to perform any additional work
+            if (Duration.between(serversLastRefresh, Instant.now()) >= serverListBeforeRefreshTimeSpan) {
+                resolveServerList(forceRefresh = true)
+            } else {
+                // no work needs to be done
+            }
+        } else {
+            resolveServerList()
         }
-
-        resolveServerList()
     }
 
     @Throws(IOException::class)
-    private fun resolveServerList() {
-        logger.debug("Resolving server list")
+    private fun resolveServerList(forceRefresh: Boolean = false) {
+        var forcedRefresh = forceRefresh
+
+        val providerRefreshTime = configuration.serverListProvider.lastServerListRefresh
+        var alreadyTriedDirectoryFetch = false
+
+        // If this is the first time the server list is being resolved,
+        // check if the cache is old enough that requires refreshing from the API first
+        if (!forceRefresh && Duration.between(providerRefreshTime, Instant.now()) >= serverListBeforeRefreshTimeSpan) {
+            forcedRefresh = true
+        }
+
+        // Server list can only be force refreshed if the API is allowed in the first place
+        if (forcedRefresh && configuration.isAllowDirectoryFetch) {
+            logger.debug("Querying SteamDirectory for a fresh server list")
+
+            val directoryList = SteamDirectory.load(configuration)
+
+            alreadyTriedDirectoryFetch = true
+
+            // Fresh server list has been loaded
+            if (directoryList.isNotEmpty()) {
+                logger.debug("Resolved ${directoryList.size} servers from SteamDirectory")
+
+                replaceList(directoryList, writeProvider = true, Instant.now())
+                return
+            }
+
+            logger.debug("Could not query SteamDirectory, falling back to provider")
+        } else {
+            logger.debug("Resolving server list using the provider")
+        }
 
         val serverList = configuration.serverListProvider.fetchServerList()
         var endpointList = serverList.toList()
 
-        if (endpointList.isEmpty() && configuration.isAllowDirectoryFetch) {
+        // Provider server list is fresh enough and it provided servers
+        if (endpointList.isNotEmpty()) {
+            logger.debug("Resolved ${endpointList.size} servers from the provider")
+            replaceList(endpointList, writeProvider = false, providerRefreshTime)
+            return
+        }
+
+        // If API fetch is not allowed, bail out with no servers
+        if (!configuration.isAllowDirectoryFetch) {
+            logger.debug("Server list provider had no entries, and SteamConfiguration.isAllowDirectoryFetch is false")
+            replaceList(listOf(), writeProvider = false, Instant.MIN)
+            return
+        }
+
+        // If the force refresh tried to fetch the server list already, do not fetch it again
+        if (!alreadyTriedDirectoryFetch) {
             logger.debug("Server list provider had no entries, will query SteamDirectory")
             endpointList = SteamDirectory.load(configuration)
+
+            if (endpointList.isNotEmpty()) {
+                logger.debug("Resolved ${endpointList.size} servers from SteamDirectory")
+                replaceList(endpointList, writeProvider = true, Instant.now())
+                return
+            }
         }
 
-        if (endpointList.isEmpty() && configuration.isAllowDirectoryFetch) {
-            logger.debug("Could not query SteamDirectory, falling back to cm2-ord1")
+        // This is a last effort to attempt any valid connection to Steam
+        logger.debug("Server list provider had no entries, SteamDirectory failed, falling back to default servers")
 
-            // Grabbed a random host that is not an IP address from the endpoint list.
-            val cm0 = InetSocketAddress("cm2-ord1.cm.steampowered.com", 27017)
-            endpointList = listOf(ServerRecord.createSocketServer(cm0))
-        }
+        endpointList = listOfNotNull(
+            ServerRecord.createWebSocketServer(defaultServerWebSocket),
+            ServerRecord.tryCreateSocketServer(defaultServerNetFilter), // TODO 'tryCreateSocketServer' can return null
+        )
 
-        logger.debug("Resolved ${endpointList.size} servers")
-        replaceList(endpointList)
+        replaceList(endpointList, writeProvider = false, Instant.MIN)
     }
 
     /**
@@ -77,15 +160,21 @@ class SmartCMServerList(private val configuration: SteamConfiguration) {
      * Replace the list with a new list of servers provided to us by the Steam servers.
      *
      * @param endpointList The [ServerRecord] to use for this [SmartCMServerList].
+     * @param writeProvider If true, the replaced list will be updated in the server list provider.
+     * @param serversTime The time when the provided server list has been updated.
      */
-    fun replaceList(endpointList: List<ServerRecord>) {
+    @JvmOverloads
+    fun replaceList(endpointList: List<ServerRecord>, writeProvider: Boolean = true, serversTime: Instant? = null) {
         val distinctEndPoints = endpointList.distinct()
 
+        serversLastRefresh = serversTime ?: Instant.now()
         servers.clear()
 
         distinctEndPoints.forEach(::addCore)
 
-        configuration.serverListProvider.updateServerList(distinctEndPoints)
+        if (writeProvider) {
+            configuration.serverListProvider.updateServerList(distinctEndPoints)
+        }
     }
 
     private fun addCore(endPoint: ServerRecord) {
@@ -173,13 +262,17 @@ class SmartCMServerList(private val configuration: SteamConfiguration) {
      * @return An [ServerRecord], or null if the list is empty.
      */
     fun getNextServerCandidate(supportedProtocolTypes: EnumSet<ProtocolTypes>): ServerRecord? {
-        try {
+        return runCatching {
             startFetchingServers()
-        } catch (e: IOException) {
-            return null
-        }
-
-        return getNextServerCandidateInternal(supportedProtocolTypes)
+        }.fold(
+            onSuccess = {
+                getNextServerCandidateInternal(supportedProtocolTypes)
+            },
+            onFailure = { error ->
+                logger.error("Error while fetching servers", error)
+                return null
+            }
+        )
     }
 
     /**
@@ -193,20 +286,30 @@ class SmartCMServerList(private val configuration: SteamConfiguration) {
 
     /**
      * Gets the [ServerRecords][ServerRecord] of all servers in the server list.
-     *
-     * @return An [List] array contains the [ServerRecords][ServerRecord] of the servers in the list
+     * @return An [List] array contains the [InetSocketAddress] of the servers in the list
      */
-    fun getAllEndPoints(): List<ServerRecord?> {
-        runCatching {
-            startFetchingServers()
-        }.onFailure { return emptyList() }
+    fun getAllEndPoints(): List<ServerRecord> = runCatching {
+        startFetchingServers()
+    }.fold(
+        onSuccess = { servers.map { s -> s.record }.distinct() },
+        onFailure = { error ->
+            logger.error("Failed to fetch end points", error)
+            emptyList()
+        }
+    )
 
-        val endPoints = servers.map { s -> s.record }.distinct()
-
-        return endPoints
-    }
-
-    companion object {
-        private val logger: Logger = LogManager.getLogger(SmartCMServerList::class.java)
-    }
+    /**
+     * Force refresh the server list. If directory fetch is allowed, it will refresh from the API first,
+     * and then fallback to the server list provider.
+     * @return whether the refresh was successful or not.
+     **/
+    fun forceRefreshServerList(): Boolean = runCatching {
+        resolveServerList(forceRefresh = true)
+    }.fold(
+        onSuccess = { true },
+        onFailure = { error ->
+            logger.error(error)
+            false
+        }
+    )
 }

--- a/src/main/java/in/dragonbra/javasteam/util/NetHelpers.kt
+++ b/src/main/java/in/dragonbra/javasteam/util/NetHelpers.kt
@@ -3,13 +3,13 @@ package `in`.dragonbra.javasteam.util
 import com.google.protobuf.ByteString
 import `in`.dragonbra.javasteam.generated.MsgClientLogon
 import `in`.dragonbra.javasteam.protobufs.steamclient.SteammessagesBase.CMsgIPAddress
-import org.apache.commons.validator.routines.InetAddressValidator
 import java.lang.IllegalArgumentException
 import java.net.DatagramSocket
 import java.net.Inet6Address
 import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.Socket
+import java.net.UnknownHostException
 import java.nio.ByteBuffer
 
 /**
@@ -55,12 +55,10 @@ object NetHelpers {
     }
 
     @JvmStatic
-    fun getIPAddress(ipAddr: CMsgIPAddress): InetAddress {
-        return if (ipAddr.hasV6()) {
-            InetAddress.getByAddress(ipAddr.v6.toByteArray())
-        } else {
-            getIPAddress(ipAddr.v4)
-        }
+    fun getIPAddress(ipAddr: CMsgIPAddress): InetAddress = if (ipAddr.hasV6()) {
+        InetAddress.getByAddress(ipAddr.v6.toByteArray())
+    } else {
+        getIPAddress(ipAddr.v4)
     }
 
     @JvmStatic
@@ -106,16 +104,15 @@ object NetHelpers {
             }
 
             var ip = stringValue.substring(0, split)
-            val port = stringValue.substring(split + 1).toInt()
+            val port = stringValue.substring(split + 1).toIntOrNull() ?: return null
 
             if (ip.startsWith("[") && ip.endsWith("]")) {
                 ip = ip.substring(1, ip.length - 1) // Remove the brackets
             }
 
-            val validator = InetAddressValidator.getInstance()
-            return if (validator.isValidInet4Address(ip) || validator.isValidInet6Address(ip)) {
+            return try {
                 InetSocketAddress(ip, port)
-            } else {
+            } catch (e: UnknownHostException) {
                 null
             }
         } catch (_: Exception) {

--- a/src/test/java/in/dragonbra/javasteam/steam/discovery/FileServerListProviderTest.java
+++ b/src/test/java/in/dragonbra/javasteam/steam/discovery/FileServerListProviderTest.java
@@ -2,52 +2,120 @@ package in.dragonbra.javasteam.steam.discovery;
 
 import in.dragonbra.javasteam.TestBase;
 import in.dragonbra.javasteam.networking.steam3.ProtocolTypes;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.EnumSet;
 import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 
 public class FileServerListProviderTest extends TestBase {
 
     @TempDir
-    Path folder;
+    Path tempDir;
 
     @Test
-    public void testSaveAndRead() throws IOException {
-        final Path tempFile = Files.createFile(folder.resolve("FileServerListProvider.txt"));
+    public void testInitializationWithPath() {
+        var path = Path.of("servertest.bin");
+        var provider = new FileServerListProvider(path);
 
-        FileServerListProvider provider = new FileServerListProvider(tempFile.toFile());
-
-        List<ServerRecord> serverRecords = new ArrayList<>();
-
-        serverRecords.add(ServerRecord.createServer("162.254.197.42", 27017, ProtocolTypes.TCP));
-        serverRecords.add(ServerRecord.createServer("162.254.197.42", 27018, ProtocolTypes.TCP));
-        serverRecords.add(ServerRecord.createServer("162.254.197.42", 27017, ProtocolTypes.UDP));
-        serverRecords.add(ServerRecord.createServer("CM02-FRA.cm.steampowered.com", 27017, ProtocolTypes.WEB_SOCKET));
-
-        provider.updateServerList(serverRecords);
-
-        List<ServerRecord> loadedList = provider.fetchServerList();
-
-        assertEquals(loadedList, serverRecords);
+        Assertions.assertEquals("servertest.bin", provider.getFile().getFileName().toString());
+        Assertions.assertNotNull(provider);
     }
 
     @Test
-    public void testMissingFile() throws IOException {
-        final Path tempFile = Files.createFile(folder.resolve("FileServerListProvider.txt"));
+    public void testInitializationWithFile() {
+        var file = new File("servertest.bin");
+        var provider = new FileServerListProvider(file);
 
-        FileServerListProvider provider = new FileServerListProvider(tempFile.toFile());
+        Assertions.assertEquals("servertest.bin", provider.getFile().getFileName().toString());
+        Assertions.assertNotNull(provider);
+    }
 
-        List<ServerRecord> serverRecords = provider.fetchServerList();
+    @Test
+    public void testInitializationWithString() {
+        var fileName = "servertest.bin";
+        var provider = new FileServerListProvider(fileName);
 
-        assertTrue(serverRecords.isEmpty());
+        Assertions.assertEquals("servertest.bin", provider.getFile().getFileName().toString());
+        Assertions.assertNotNull(provider);
+    }
+
+    @Test
+    public void testFetchServerListWithNoFile() {
+        var file = tempDir.resolve("servertest.bin");
+        var provider = new FileServerListProvider(file);
+
+        var servers = provider.fetchServerList();
+
+        Assertions.assertTrue(servers.isEmpty());
+        Assertions.assertFalse(file.toFile().exists());
+    }
+
+    @Test
+    public void testUpdateServerList() {
+        var file = new File("servertest.bin");
+        var provider = new FileServerListProvider(file);
+
+        var serverRecords = List.of(
+                ServerRecord.createServer("127.0.0.1", 8080, ProtocolTypes.TCP),
+                ServerRecord.createServer("192.168.0.1", 8081, ProtocolTypes.UDP),
+                ServerRecord.createServer("0.0.0.0", 8081, ProtocolTypes.WEB_SOCKET)
+        );
+
+        provider.updateServerList(serverRecords);
+
+        var servers = provider.fetchServerList();
+
+        Assertions.assertEquals(3, servers.size());
+        Assertions.assertTrue(file.exists());
+    }
+
+    @Test
+    public void testReadsUpdatedServerList() throws IOException {
+        var fileStorageProvider = new FileServerListProvider("servertest.bin");
+        fileStorageProvider.fetchServerList();
+
+        fileStorageProvider.updateServerList(List.of(
+                ServerRecord.createSocketServer(new InetSocketAddress(InetAddress.getByName("0.0.0.0"), 1234)),
+                ServerRecord.createSocketServer(new InetSocketAddress(InetAddress.getLoopbackAddress(), 4321))
+        ));
+
+        var servers = fileStorageProvider.fetchServerList();
+        Assertions.assertEquals(2, servers.size());
+
+        ServerRecord firstServer = servers.get(0);
+        Assertions.assertEquals("0.0.0.0", firstServer.getHost());
+        Assertions.assertEquals(1234, firstServer.getPort());
+        Assertions.assertEquals(EnumSet.of(ProtocolTypes.TCP, ProtocolTypes.UDP), firstServer.getProtocolTypes());
+
+        var file = Path.of("servertest.bin");
+        Files.deleteIfExists(file);
+        Assertions.assertFalse(file.toFile().exists());
+    }
+
+    @Test
+    public void testLastServerListRefresh() throws IOException {
+        var tempFile = tempDir.resolve("servertest.bin");
+
+        FileServerListProvider provider = new FileServerListProvider(tempFile);
+
+        provider.updateServerList(List.of());
+
+        var now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+        var lastRefresh = provider.getLastServerListRefresh().truncatedTo(ChronoUnit.SECONDS);
+        Assertions.assertEquals(now, lastRefresh);
+
+        var file = Path.of("servertest.bin");
+        Files.deleteIfExists(file);
+        Assertions.assertFalse(file.toFile().exists());
     }
 }

--- a/src/test/java/in/dragonbra/javasteam/steam/discovery/ServerRecordTest.java
+++ b/src/test/java/in/dragonbra/javasteam/steam/discovery/ServerRecordTest.java
@@ -90,7 +90,8 @@ public class ServerRecordTest extends TestBase {
         record = ServerRecord.tryCreateSocketServer("127.0.0.1:notanint");
         assertNull(record);
 
-        record = ServerRecord.tryCreateSocketServer("volvopls.valvesoftware.com:1234");
-        assertNull(record);
+        // I don't think this is needed anymore, since we `can` tryCreateSocketServer with subdomain + port.
+        //record = ServerRecord.tryCreateSocketServer("volvopls.valvesoftware.com:1234");
+        //assertNull(record);
     }
 }

--- a/src/test/java/in/dragonbra/javasteam/steam/discovery/SmartCMServerListTest.java
+++ b/src/test/java/in/dragonbra/javasteam/steam/discovery/SmartCMServerListTest.java
@@ -222,7 +222,7 @@ public class SmartCMServerListTest extends TestBase {
             try {
                 TimeUnit.MILLISECONDS.sleep(10);
             } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
+                Assertions.fail(e);
             }
             serverList.tryMark(candidate.getEndpoint(), ProtocolTypes.WEB_SOCKET, ServerQuality.BAD);
         };
@@ -256,7 +256,7 @@ public class SmartCMServerListTest extends TestBase {
             try {
                 TimeUnit.MILLISECONDS.sleep(10);
             } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
+                Assertions.fail(e);
             }
             serverList.tryMark(candidate.getEndpoint(), ProtocolTypes.WEB_SOCKET, ServerQuality.BAD);
         };

--- a/src/test/java/in/dragonbra/javasteam/steam/steamclient/configuration/SteamConfigurationConfiguredObjectTest.java
+++ b/src/test/java/in/dragonbra/javasteam/steam/steamclient/configuration/SteamConfigurationConfiguredObjectTest.java
@@ -6,9 +6,11 @@ import in.dragonbra.javasteam.networking.steam3.ProtocolTypes;
 import in.dragonbra.javasteam.steam.discovery.IServerListProvider;
 import in.dragonbra.javasteam.steam.discovery.ServerRecord;
 import okhttp3.OkHttpClient;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -92,6 +94,11 @@ public class SteamConfigurationConfiguredObjectTest {
     }
 
     static class CustomServerListProvider implements IServerListProvider {
+        @Override
+        public @NotNull Instant getLastServerListRefresh() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
         @Override
         public List<ServerRecord> fetchServerList() {
             throw new UnsupportedOperationException("Not supported yet.");


### PR DESCRIPTION
### Description
Bring functionality for the server list to refresh itself. 

SmartCMServerList has getters/setters for static method `defaultServerWebSocket` and `defaultServerNetFilter`. By default they have Seattle CM's. 

You can change the remember duration by referencing `steamclient.getServers().setServerListBeforeRefreshTimeSpan(<Duration>)` or `steamclient.getServers().setBadConnectionMemoryTimeSpan(<Duration>)`.

>Server list providers now return the last time they were written (I had to add a bool to ReplaceList to avoid rewriting the file if its using provider list).

>By default it will consider server list newer than 7 days as fresh. If it fails to refresh the list from API, it will use the previous logic of using the provider.

From SK PR 1452
### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
