### PR TITLE
Allow ContentDownloader to be more flexible

### DIFF
--- a/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_023_downloadapp/SampleDownloadApp.java
+++ b/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_023_downloadapp/SampleDownloadApp.java
@@ -36,6 +36,7 @@ public class SampleDownloadApp implements Runnable {
 
     private final int ROCKY_MAYHEM_APP_ID = 1303350;
     private final int ROCKY_MAYHEM_DEPOT_ID = 1303351;
+    private final long ROCKY_MAYHEM_MANIFEST_ID = 6150762840934915019L;
 
     private SteamClient steamClient;
 
@@ -179,6 +180,8 @@ public class SampleDownloadApp implements Runnable {
         contentDownloader.downloadApp(
                 ROCKY_MAYHEM_APP_ID,
                 ROCKY_MAYHEM_DEPOT_ID,
+                ROCKY_MAYHEM_MANIFEST_ID,
+                "Rocky Mayhem",
                 "steamapps/",
                 "steamapps/staging/",
                 "public",


### PR DESCRIPTION
### Description
With the following changes, it is possible to download any old version of game and no longer need to send repeated network requests.

- Add manifest ID and app name parameters to downloadApp methods.
- Remove unnecessary requests to get app info, it should be called by the user and passed in.

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
