### PR TITLE
Deprecate spongy castle

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ Maven
 
 **3. Add the appropriate cryptography dependency to your project. JavaSteam depends on this.**
 
-[Android | Spongy Castle](https://mvnrepository.com/artifact/com.madgag.spongycastle/prov)
+[Android (Deprecated) | Spongy Castle](https://mvnrepository.com/artifact/com.madgag.spongycastle/prov)
 
-[Non-Android | Bouncy Castle](https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk18on)
+[Android and Non-Android | Bouncy Castle](https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk18on)
 
 **4. (Optional) Working with protobufs.**
 
@@ -60,7 +60,7 @@ Note: To eliminate any errors or warnings, you should try and match the same ver
 
 ## Getting Started
 
-You can head to the very short [Getting Started](https://github.com/Longi94/JavaSteam/wiki/Getting-started) page or take a look at the [samples](https://github.com/Longi94/JavaSteam/tree/master/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples) to get you started with using this library. 
+You can head to the very short [Getting Started](https://github.com/Longi94/JavaSteam/wiki/Getting-started) page or take a look at the [samples](https://github.com/Longi94/JavaSteam/tree/master/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples) to get you started with using this library.
 
 There some [open-source projects](https://github.com/Longi94/JavaSteam/wiki/Samples) too you can check out.
 

--- a/src/main/java/in/dragonbra/javasteam/util/crypto/CryptoHelper.java
+++ b/src/main/java/in/dragonbra/javasteam/util/crypto/CryptoHelper.java
@@ -32,13 +32,22 @@ public class CryptoHelper {
     static {
         try {
             if (Utils.getOSType() == EOSType.AndroidUnknown) {
-                Class<? extends Provider> provider =
-                        (Class<? extends Provider>) Class.forName("org.spongycastle.jce.provider.BouncyCastleProvider");
-                Security.insertProviderAt(provider.getDeclaredConstructor().newInstance(), 1);
-                SEC_PROV = "SC";
+                String androidSecProv;
+                try {
+                    // Try SpongyCastle (This will slowly be phased out. Noted 1/1/2025)
+                    var provider = (Class<? extends Provider>) Class.forName("org.spongycastle.jce.provider.BouncyCastleProvider");
+                    Security.insertProviderAt(provider.getDeclaredConstructor().newInstance(), 1);
+                    androidSecProv = "SC";
+                } catch (Exception e) {
+                    // Try BouncyCastle as fallback
+                    var provider = (Class<? extends Provider>) Class.forName("org.bouncycastle.jce.provider.BouncyCastleProvider");
+                    Security.insertProviderAt(provider.getDeclaredConstructor().newInstance(), 1);
+                    androidSecProv = "BC";
+                }
+
+                SEC_PROV = androidSecProv;
             } else {
-                Class<? extends Provider> provider =
-                        (Class<? extends Provider>) Class.forName("org.bouncycastle.jce.provider.BouncyCastleProvider");
+                var provider = (Class<? extends Provider>) Class.forName("org.bouncycastle.jce.provider.BouncyCastleProvider");
                 Security.addProvider(provider.getDeclaredConstructor().newInstance());
                 SEC_PROV = "BC";
             }

--- a/src/main/java/in/dragonbra/javasteam/util/crypto/CryptoHelper.java
+++ b/src/main/java/in/dragonbra/javasteam/util/crypto/CryptoHelper.java
@@ -34,7 +34,7 @@ public class CryptoHelper {
             if (Utils.getOSType() == EOSType.AndroidUnknown) {
                 String androidSecProv;
                 try {
-                    // Try SpongyCastle (This will slowly be phased out. Noted 1/1/2025)
+                    // Try SpongyCastle (This will be phased out someday. Noted 1/1/2025)
                     var provider = (Class<? extends Provider>) Class.forName("org.spongycastle.jce.provider.BouncyCastleProvider");
                     Security.insertProviderAt(provider.getDeclaredConstructor().newInstance(), 1);
                     androidSecProv = "SC";
@@ -54,6 +54,8 @@ public class CryptoHelper {
         } catch (Exception e) {
             throw new SecurityException("Couldn't create security provider", e);
         }
+
+        logger.debug("Using security provider: " + SEC_PROV);
     }
 
     public static byte[] shaHash(byte[] input) throws NoSuchAlgorithmException {


### PR DESCRIPTION
### Description
See: #261 for more information.

- Allows Android to use BC or SC for CryptoHelper.
- Readme updated to reflect changes. 

The wiki will need to be udpated too with these changes once merged. 

Closes: #271

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
