### PR TITLE
Resource closing with other fixes

### DIFF
--- a/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_000_authentication/SampleLogonAuthentication.java
+++ b/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_000_authentication/SampleLogonAuthentication.java
@@ -123,11 +123,11 @@ public class SampleLogonAuthentication implements Runnable {
 
         try {
             // Begin authenticating via credentials.
-            var authSession = steamClient.getAuthentication().beginAuthSessionViaCredentials(authDetails);
+            var authSession = steamClient.getAuthentication().beginAuthSessionViaCredentialsFuture(authDetails).get();
 
             // Note: This is blocking, it would be up to you to make it non-blocking for Java.
             // Note: Kotlin uses should use ".pollingWaitForResult()" as its a suspending function.
-            AuthPollResult pollResponse = authSession.pollingWaitForResultCompat().get();
+            AuthPollResult pollResponse = authSession.pollingWaitForResultFuture().get();
 
             if (pollResponse.getNewGuardData() != null) {
                 // When using certain two factor methods (such as email 2fa), guard data may be provided by Steam

--- a/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_000_authentication/SampleLogonAuthentication.java
+++ b/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_000_authentication/SampleLogonAuthentication.java
@@ -17,7 +17,11 @@ import in.dragonbra.javasteam.steam.steamclient.callbacks.DisconnectedCallback;
 import in.dragonbra.javasteam.util.log.DefaultLogListener;
 import in.dragonbra.javasteam.util.log.LogManager;
 
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Base64;
+import java.util.List;
 import java.util.concurrent.CancellationException;
 
 /**
@@ -38,6 +42,8 @@ public class SampleLogonAuthentication implements Runnable {
     private final String user;
 
     private final String pass;
+
+    private List<Closeable> subscriptions;
 
     private String previouslyStoredGuardData; // For the sake of this sample, we do not persist guard data
 
@@ -76,14 +82,18 @@ public class SampleLogonAuthentication implements Runnable {
         // get the steamuser handler, which is used for logging on after successfully connecting
         steamUser = steamClient.getHandler(SteamUser.class);
 
+        // The callbacks are a closeable, and to properly fix
+        // "'Closeable' used without 'try'-with-resources statement", they should be closed once done.
+        // Usually putting them in a list and close each of them once the client is finished is recommended.
+        subscriptions = new ArrayList<>();
+
         // register a few callbacks we're interested in
         // these are registered upon creation to a callback manager, which will then route the callbacks
         // to the functions specified
-        manager.subscribe(ConnectedCallback.class, this::onConnected);
-        manager.subscribe(DisconnectedCallback.class, this::onDisconnected);
-
-        manager.subscribe(LoggedOnCallback.class, this::onLoggedOn);
-        manager.subscribe(LoggedOffCallback.class, this::onLoggedOff);
+        subscriptions.add(manager.subscribe(ConnectedCallback.class, this::onConnected));
+        subscriptions.add(manager.subscribe(DisconnectedCallback.class, this::onDisconnected));
+        subscriptions.add(manager.subscribe(LoggedOnCallback.class, this::onLoggedOn));
+        subscriptions.add(manager.subscribe(LoggedOffCallback.class, this::onLoggedOff));
 
         isRunning = true;
 
@@ -96,6 +106,16 @@ public class SampleLogonAuthentication implements Runnable {
         while (isRunning) {
             // in order for the callbacks to get routed, they need to be handled by the manager
             manager.runWaitCallbacks(1000L);
+        }
+
+        // Close the subscriptions when done.
+        System.out.println("Closing " + subscriptions.size() + " callbacks");
+        for (var subscription : subscriptions) {
+            try {
+                subscription.close();
+            } catch (IOException e) {
+                System.out.println("Couldn't close a callback.");
+            }
         }
     }
 
@@ -123,11 +143,11 @@ public class SampleLogonAuthentication implements Runnable {
 
         try {
             // Begin authenticating via credentials.
-            var authSession = steamClient.getAuthentication().beginAuthSessionViaCredentialsFuture(authDetails).get();
+            var authSession = steamClient.getAuthentication().beginAuthSessionViaCredentials(authDetails).get();
 
             // Note: This is blocking, it would be up to you to make it non-blocking for Java.
             // Note: Kotlin uses should use ".pollingWaitForResult()" as its a suspending function.
-            AuthPollResult pollResponse = authSession.pollingWaitForResultFuture().get();
+            AuthPollResult pollResponse = authSession.pollingWaitForResult().get();
 
             if (pollResponse.getNewGuardData() != null) {
                 // When using certain two factor methods (such as email 2fa), guard data may be provided by Steam

--- a/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_001_authenticationwithqrcode/SampleLogonQRAuthentication.java
+++ b/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_001_authenticationwithqrcode/SampleLogonQRAuthentication.java
@@ -91,7 +91,9 @@ public class SampleLogonQRAuthentication implements Runnable, IChallengeUrlChang
             // get the authentication handler, which used for authenticating with Steam
             SteamAuthentication auth = new SteamAuthentication(steamClient);
 
-            QrAuthSession authSession = auth.beginAuthSessionViaQRFuture(new AuthSessionDetails()).get();
+            AuthSessionDetails authDetails = new AuthSessionDetails();
+
+            QrAuthSession authSession = auth.beginAuthSessionViaQR(authDetails).get();
 
             // Steam will periodically refresh the challenge url, this callback allows you to draw a new qr code.
             // Note: Callback is below.
@@ -104,7 +106,7 @@ public class SampleLogonQRAuthentication implements Runnable, IChallengeUrlChang
             // This response is later used to log on to Steam after connecting
             // Note: This is blocking, it would be up to you to make it non-blocking for Java.
             // Note: Kotlin uses should use ".pollingWaitForResult()" as its a suspending function.
-            AuthPollResult pollResponse = authSession.pollingWaitForResultFuture().get();
+            AuthPollResult pollResponse = authSession.pollingWaitForResult().get();
 
             System.out.println("Connected to Steam! Logging in " + pollResponse.getAccountName() + "...");
 

--- a/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_001_authenticationwithqrcode/SampleLogonQRAuthentication.java
+++ b/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_001_authenticationwithqrcode/SampleLogonQRAuthentication.java
@@ -7,7 +7,6 @@ import in.dragonbra.javasteam.steam.authentication.AuthSessionDetails;
 import in.dragonbra.javasteam.steam.authentication.IChallengeUrlChanged;
 import in.dragonbra.javasteam.steam.authentication.QrAuthSession;
 import in.dragonbra.javasteam.steam.authentication.SteamAuthentication;
-import in.dragonbra.javasteam.steam.handlers.steamunifiedmessages.SteamUnifiedMessages;
 import in.dragonbra.javasteam.steam.handlers.steamuser.LogOnDetails;
 import in.dragonbra.javasteam.steam.handlers.steamuser.SteamUser;
 import in.dragonbra.javasteam.steam.handlers.steamuser.callback.LoggedOffCallback;
@@ -92,7 +91,7 @@ public class SampleLogonQRAuthentication implements Runnable, IChallengeUrlChang
             // get the authentication handler, which used for authenticating with Steam
             SteamAuthentication auth = new SteamAuthentication(steamClient);
 
-            QrAuthSession authSession = auth.beginAuthSessionViaQR(new AuthSessionDetails());
+            QrAuthSession authSession = auth.beginAuthSessionViaQRFuture(new AuthSessionDetails()).get();
 
             // Steam will periodically refresh the challenge url, this callback allows you to draw a new qr code.
             // Note: Callback is below.
@@ -105,7 +104,7 @@ public class SampleLogonQRAuthentication implements Runnable, IChallengeUrlChang
             // This response is later used to log on to Steam after connecting
             // Note: This is blocking, it would be up to you to make it non-blocking for Java.
             // Note: Kotlin uses should use ".pollingWaitForResult()" as its a suspending function.
-            AuthPollResult pollResponse = authSession.pollingWaitForResultCompat().get();
+            AuthPollResult pollResponse = authSession.pollingWaitForResultFuture().get();
 
             System.out.println("Connected to Steam! Logging in " + pollResponse.getAccountName() + "...");
 

--- a/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_002_webcookie/SampleWebCookie.java
+++ b/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_002_webcookie/SampleWebCookie.java
@@ -106,11 +106,9 @@ public class SampleWebCookie implements Runnable {
         auth = new SteamAuthentication(steamClient);
 
         try {
-            CredentialsAuthSession authSession = auth.beginAuthSessionViaCredentialsFuture(authSessionDetails).get();
+            CredentialsAuthSession authSession = auth.beginAuthSessionViaCredentials(authSessionDetails).get();
 
-            // Note: This is blocking, it would be up to you to make it non-blocking for Java.
-            // Note: Kotlin uses should use ".pollingWaitForResult()" as its a suspending function.
-            AuthPollResult pollResponse = authSession.pollingWaitForResultFuture().get();
+            AuthPollResult pollResponse = authSession.pollingWaitForResult().get();
 
             LogOnDetails logOnDetails = new LogOnDetails();
             logOnDetails.setUsername(pollResponse.getAccountName());
@@ -166,9 +164,9 @@ public class SampleWebCookie implements Runnable {
         // Parse this token with a JWT library to get the expiration date and set up a timer to renew it.
         // To renew you will have to call this:
         // When allowRenewal is set to true, Steam may return new RefreshToken
-        AccessTokenGenerateResult newTokens = null;
+        AccessTokenGenerateResult newTokens;
         try {
-            newTokens = auth.generateAccessTokenForAppFuture(callback.getClientSteamID(), refreshToken, false).get();
+            newTokens = auth.generateAccessTokenForApp(callback.getClientSteamID(), refreshToken, false).get();
         } catch (InterruptedException | ExecutionException e) {
             throw new RuntimeException(e);
         }

--- a/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_013_unifiedmessages/SampleUnifiedMessages.java
+++ b/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_013_unifiedmessages/SampleUnifiedMessages.java
@@ -156,9 +156,9 @@ public class SampleUnifiedMessages implements Runnable {
         authDetails.authenticator = new UserConsoleAuthenticator();
 
         try {
-            var authSession = steamClient.getAuthentication().beginAuthSessionViaCredentialsFuture(authDetails).get();
+            var authSession = steamClient.getAuthentication().beginAuthSessionViaCredentials(authDetails).get();
 
-            AuthPollResult pollResponse = authSession.pollingWaitForResultFuture().get();
+            AuthPollResult pollResponse = authSession.pollingWaitForResult().get();
 
             LogOnDetails details = new LogOnDetails();
             details.setUsername(pollResponse.getAccountName());

--- a/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_013_unifiedmessages/SampleUnifiedMessages.java
+++ b/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_013_unifiedmessages/SampleUnifiedMessages.java
@@ -29,6 +29,8 @@ import in.dragonbra.javasteam.types.SteamID;
 import in.dragonbra.javasteam.util.log.DefaultLogListener;
 import in.dragonbra.javasteam.util.log.LogManager;
 
+import java.util.concurrent.ExecutionException;
+
 /**
  * @author Lossy
  * @since 2023-01-04
@@ -219,31 +221,40 @@ public class SampleUnifiedMessages implements Runnable {
                 .build();
 
         // now let's send the request and await for the response
-        var response = playerService.getGameBadgeLevels(req).runBlock();
-        System.out.println("Main Request:");
-        if (response.getResult() != EResult.OK) {
-            System.err.println("Unified service request failed with " + response.getResult());
-        }
-        System.out.println("Our player level is " + response.getBody().getPlayerLevel());
-        for (var badge : response.getBody().getBadgesList()) {
-            System.out.println("Badge series " + badge.toString() + " is level " + badge.getLevel());
+        try {
+            var response = playerService.getGameBadgeLevels(req).toFuture().get();
+
+            System.out.println("Main Request:");
+            if (response.getResult() != EResult.OK) {
+                System.err.println("Unified service request failed with " + response.getResult());
+            }
+            System.out.println("Our player level is " + response.getBody().getPlayerLevel());
+            for (var badge : response.getBody().getBadgesList()) {
+                System.out.println("Badge series " + badge.toString() + " is level " + badge.getLevel());
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
         }
 
         // alternatively, the request can be made using SteamUnifiedMessages directly, but then you must build the service request name manually
         // the name format is in the form of <Service>.<Method>#<Version>
-        var responseAlt = steamUnifiedMessages.sendMessage(
-                CPlayer_GetGameBadgeLevels_Response.Builder.class,
-                "Player.GetGameBadgeLevels#1",
-                req
-        ).runBlock();
+        try {
+            var responseAlt = steamUnifiedMessages.sendMessage(
+                    CPlayer_GetGameBadgeLevels_Response.Builder.class,
+                    "Player.GetGameBadgeLevels#1",
+                    req
+            ).toFuture().get();
 
-        System.out.println("Alt Request");
-        if (responseAlt.getResult() != EResult.OK) {
-            System.err.println("Unified service request failed with " + responseAlt.getResult());
-        }
-        System.out.println("Our player level is " + responseAlt.getBody().getPlayerLevel());
-        for (var badge : responseAlt.getBody().getBadgesList()) {
-            System.out.println("Badge series " + badge.toString() + " is level " + badge.getLevel());
+            System.out.println("Alt Request");
+            if (responseAlt.getResult() != EResult.OK) {
+                System.err.println("Unified service request failed with " + responseAlt.getResult());
+            }
+            System.out.println("Our player level is " + responseAlt.getBody().getPlayerLevel());
+            for (var badge : responseAlt.getBody().getBadgesList()) {
+                System.out.println("Badge series " + badge.toString() + " is level " + badge.getLevel());
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
         }
 
         // now that we've completed our task, lets log off after a few seconds to receive possible notifications

--- a/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_013_unifiedmessages/SampleUnifiedMessages.java
+++ b/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_013_unifiedmessages/SampleUnifiedMessages.java
@@ -156,9 +156,9 @@ public class SampleUnifiedMessages implements Runnable {
         authDetails.authenticator = new UserConsoleAuthenticator();
 
         try {
-            var authSession = steamClient.getAuthentication().beginAuthSessionViaCredentials(authDetails);
+            var authSession = steamClient.getAuthentication().beginAuthSessionViaCredentialsFuture(authDetails).get();
 
-            AuthPollResult pollResponse = authSession.pollingWaitForResultCompat().get();
+            AuthPollResult pollResponse = authSession.pollingWaitForResultFuture().get();
 
             LogOnDetails details = new LogOnDetails();
             details.setUsername(pollResponse.getAccountName());

--- a/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_022_pics/SamplePics.java
+++ b/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_022_pics/SamplePics.java
@@ -127,11 +127,9 @@ public class SamplePics implements Runnable {
 
         try {
             // Begin authenticating via credentials.
-            var authSession = steamClient.getAuthentication().beginAuthSessionViaCredentialsFuture(authDetails).get();
+            var authSession = steamClient.getAuthentication().beginAuthSessionViaCredentials(authDetails).get();
 
-            // Note: This is blocking, it would be up to you to make it non-blocking for Java.
-            // Note: Kotlin uses should use ".pollingWaitForResult()" as its a suspending function.
-            AuthPollResult pollResponse = authSession.pollingWaitForResultFuture().get();
+            AuthPollResult pollResponse = authSession.pollingWaitForResult().get();
 
             if (pollResponse.getNewGuardData() != null) {
                 // When using certain two factor methods (such as email 2fa), guard data may be provided by Steam

--- a/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_022_pics/SamplePics.java
+++ b/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_022_pics/SamplePics.java
@@ -127,11 +127,11 @@ public class SamplePics implements Runnable {
 
         try {
             // Begin authenticating via credentials.
-            var authSession = steamClient.getAuthentication().beginAuthSessionViaCredentials(authDetails);
+            var authSession = steamClient.getAuthentication().beginAuthSessionViaCredentialsFuture(authDetails).get();
 
             // Note: This is blocking, it would be up to you to make it non-blocking for Java.
             // Note: Kotlin uses should use ".pollingWaitForResult()" as its a suspending function.
-            AuthPollResult pollResponse = authSession.pollingWaitForResultCompat().get();
+            AuthPollResult pollResponse = authSession.pollingWaitForResultFuture().get();
 
             if (pollResponse.getNewGuardData() != null) {
                 // When using certain two factor methods (such as email 2fa), guard data may be provided by Steam

--- a/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_023_downloadapp/SampleDownloadApp.java
+++ b/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_023_downloadapp/SampleDownloadApp.java
@@ -174,6 +174,7 @@ public class SampleDownloadApp implements Runnable {
         }
 
         // we have successfully received a free license for Rocky Mayhem so now we can start the download process
+        // note: it is okay to see some errors about ContentDownloader failing to download a chunk, it will retry and continue.
         new File("steamapps/staging/").mkdirs();
         var contentDownloader = new ContentDownloader(steamClient);
         contentDownloader.downloadApp(

--- a/src/main/java/in/dragonbra/javasteam/base/AClientMsgProtobuf.java
+++ b/src/main/java/in/dragonbra/javasteam/base/AClientMsgProtobuf.java
@@ -123,8 +123,8 @@ public class AClientMsgProtobuf extends MsgBase<MsgHdrProtoBuf> {
 
     @Override
     public void deserialize(byte[] data) {
-        try {
-            getHeader().deserialize(new ByteArrayInputStream(data));
+        try(var bais = new ByteArrayInputStream(data)) {
+            getHeader().deserialize(bais);
         } catch (IOException e) {
             logger.debug(e);
         }

--- a/src/main/java/in/dragonbra/javasteam/base/ClientGCMsg.java
+++ b/src/main/java/in/dragonbra/javasteam/base/ClientGCMsg.java
@@ -144,17 +144,17 @@ public class ClientGCMsg<BodyType extends IGCSerializableMessage> extends GCMsgB
 
     @Override
     public byte[] serialize() {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream(0);
-
-        try {
+        try (var baos = new ByteArrayOutputStream(0)) {
             getHeader().serialize(baos);
             body.serialize(baos);
             baos.write(payload.toByteArray());
+
+            return baos.toByteArray();
         } catch (IOException e) {
             logger.debug(e);
         }
 
-        return baos.toByteArray();
+        return new byte[0];
     }
 
     @Override
@@ -173,5 +173,7 @@ public class ClientGCMsg<BodyType extends IGCSerializableMessage> extends GCMsgB
 
         payload.write(data, (int) ms.getPosition(), ms.available());
         payload.seek(0, SeekOrigin.BEGIN);
+
+        ms.close();
     }
 }

--- a/src/main/java/in/dragonbra/javasteam/base/ClientGCMsgProtobuf.java
+++ b/src/main/java/in/dragonbra/javasteam/base/ClientGCMsgProtobuf.java
@@ -149,16 +149,15 @@ public class ClientGCMsgProtobuf<BodyType extends GeneratedMessage.Builder<BodyT
 
     @Override
     public byte[] serialize() {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        try {
+        try (var baos = new ByteArrayOutputStream()) {
             getHeader().serialize(baos);
             body.build().writeTo(baos);
             baos.write(payload.toByteArray());
+            return baos.toByteArray();
         } catch (IOException ignored) {
         }
 
-        return baos.toByteArray();
+        return new byte[0];
     }
 
     @SuppressWarnings("unchecked")
@@ -167,9 +166,8 @@ public class ClientGCMsgProtobuf<BodyType extends GeneratedMessage.Builder<BodyT
         if (data == null) {
             throw new IllegalArgumentException("data is null");
         }
-        BinaryReader ms = new BinaryReader(new ByteArrayInputStream(data));
 
-        try {
+        try (var ms = new BinaryReader(new ByteArrayInputStream(data))) {
             getHeader().deserialize(ms);
             final Method m = clazz.getMethod("newBuilder");
             body = (BodyType) m.invoke(null);

--- a/src/main/java/in/dragonbra/javasteam/base/ClientMsg.java
+++ b/src/main/java/in/dragonbra/javasteam/base/ClientMsg.java
@@ -167,17 +167,17 @@ public class ClientMsg<BodyType extends ISteamSerializableMessage> extends MsgBa
 
     @Override
     public byte[] serialize() {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream(0);
-
-        try {
+        try (var baos = new ByteArrayOutputStream(0)) {
             getHeader().serialize(baos);
             body.serialize(baos);
             baos.write(payload.toByteArray());
+
+            return baos.toByteArray();
         } catch (IOException e) {
             logger.debug(e);
         }
 
-        return baos.toByteArray();
+        return new byte[0];
     }
 
     @Override
@@ -196,6 +196,8 @@ public class ClientMsg<BodyType extends ISteamSerializableMessage> extends MsgBa
 
         payload.write(data, (int) ms.getPosition(), ms.available());
         payload.seek(0, SeekOrigin.BEGIN);
+
+        ms.close();
     }
 
     /**

--- a/src/main/java/in/dragonbra/javasteam/base/ClientMsgProtobuf.java
+++ b/src/main/java/in/dragonbra/javasteam/base/ClientMsgProtobuf.java
@@ -134,16 +134,17 @@ public class ClientMsgProtobuf<BodyType extends GeneratedMessage.Builder<BodyTyp
 
     @Override
     public byte[] serialize() {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream(0);
-
-        try {
+        try (var baos = new ByteArrayOutputStream(0)) {
             getHeader().serialize(baos);
             baos.write(body.build().toByteArray());
             baos.write(payload.toByteArray());
+
+            return baos.toByteArray();
         } catch (IOException e) {
             logger.debug(e);
         }
-        return baos.toByteArray();
+
+        return new byte[0];
     }
 
     @SuppressWarnings("unchecked")
@@ -165,5 +166,11 @@ public class ClientMsgProtobuf<BodyType extends GeneratedMessage.Builder<BodyTyp
             logger.debug(e);
         }
 
+        // TODO can be MemoryStream?
+        try {
+            ms.close();
+        } catch (IOException e) {
+            logger.debug(e);
+        }
     }
 }

--- a/src/main/java/in/dragonbra/javasteam/base/Msg.java
+++ b/src/main/java/in/dragonbra/javasteam/base/Msg.java
@@ -156,15 +156,17 @@ public class Msg<BodyType extends ISteamSerializableMessage> extends MsgBase<Msg
 
     @Override
     public byte[] serialize() {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream(0);
-        try {
+        try (var baos = new ByteArrayOutputStream(0)) {
             getHeader().serialize(baos);
             body.serialize(baos);
             baos.write(payload.toByteArray());
+
+            return baos.toByteArray();
         } catch (IOException e) {
             logger.debug(e);
         }
-        return baos.toByteArray();
+
+        return new byte[0];
     }
 
     @Override
@@ -183,6 +185,8 @@ public class Msg<BodyType extends ISteamSerializableMessage> extends MsgBase<Msg
 
         payload.write(data, (int) ms.getPosition(), ms.available());
         payload.seek(0, SeekOrigin.BEGIN);
+
+        ms.close();
     }
 
     public BodyType getBody() {

--- a/src/main/java/in/dragonbra/javasteam/base/PacketClientGCMsg.java
+++ b/src/main/java/in/dragonbra/javasteam/base/PacketClientGCMsg.java
@@ -36,7 +36,7 @@ public class PacketClientGCMsg implements IPacketGCMsg {
         MsgGCHdr gcHdr = new MsgGCHdr();
 
         // we need to pull out the job ids, so we deserialize the protobuf header
-        try (ByteArrayInputStream bais = new ByteArrayInputStream(data)) {
+        try (var bais = new ByteArrayInputStream(data)) {
             gcHdr.deserialize(bais);
         } catch (IOException ignored) {
         }

--- a/src/main/java/in/dragonbra/javasteam/base/PacketClientGCMsgProtobuf.java
+++ b/src/main/java/in/dragonbra/javasteam/base/PacketClientGCMsgProtobuf.java
@@ -36,7 +36,7 @@ public class PacketClientGCMsgProtobuf implements IPacketGCMsg {
         MsgGCHdrProtoBuf protobufHeader = new MsgGCHdrProtoBuf();
 
         // we need to pull out the job ids, so we deserialize the protobuf header
-        try (ByteArrayInputStream bais = new ByteArrayInputStream(data)) {
+        try (var bais = new ByteArrayInputStream(data)) {
             protobufHeader.deserialize(bais);
         } catch (IOException ignored) {
         }

--- a/src/main/java/in/dragonbra/javasteam/base/PacketClientMsg.java
+++ b/src/main/java/in/dragonbra/javasteam/base/PacketClientMsg.java
@@ -32,7 +32,7 @@ public class PacketClientMsg implements IPacketMsg {
 
         ExtendedClientMsgHdr extendedHdr = new ExtendedClientMsgHdr();
 
-        try (ByteArrayInputStream stream = new ByteArrayInputStream(data)) {
+        try (var stream = new ByteArrayInputStream(data)) {
             extendedHdr.deserialize(stream);
         }
 

--- a/src/main/java/in/dragonbra/javasteam/base/PacketClientMsgProtobuf.java
+++ b/src/main/java/in/dragonbra/javasteam/base/PacketClientMsgProtobuf.java
@@ -30,7 +30,7 @@ public class PacketClientMsgProtobuf implements IPacketMsg {
 
         header = new MsgHdrProtoBuf();
 
-        try (ByteArrayInputStream stream = new ByteArrayInputStream(data)) {
+        try (var stream = new ByteArrayInputStream(data)) {
             header.deserialize(stream);
         }
     }

--- a/src/main/java/in/dragonbra/javasteam/base/PacketMsg.java
+++ b/src/main/java/in/dragonbra/javasteam/base/PacketMsg.java
@@ -32,7 +32,7 @@ public class PacketMsg implements IPacketMsg {
 
         MsgHdr msgHdr = new MsgHdr();
 
-        try (ByteArrayInputStream stream = new ByteArrayInputStream(data)) {
+        try (var stream = new ByteArrayInputStream(data)) {
             msgHdr.deserialize(stream);
         }
 

--- a/src/main/java/in/dragonbra/javasteam/steam/CMClient.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/CMClient.java
@@ -391,7 +391,8 @@ public abstract class CMClient {
         ClientMsgProtobuf<CMsgClientLogonResponse.Builder> logonResp = new ClientMsgProtobuf<>(CMsgClientLogonResponse.class, packetMsg);
 
         EResult logonResponse = EResult.from(logonResp.getBody().getEresult());
-        logger.debug("handleLogOnResponse got response: " + logonResponse);
+        EResult extendedResponse = EResult.from(logonResp.getBody().getEresultExtended());
+        logger.debug("handleLogOnResponse got response: " + logonResponse + ", extended: " + extendedResponse);
 
         // Note: Sometimes if you sign in too many times, steam may confuse "InvalidPassword" with "RateLimitExceeded"
 

--- a/src/main/java/in/dragonbra/javasteam/steam/authentication/AuthSession.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/authentication/AuthSession.kt
@@ -7,10 +7,10 @@ import `in`.dragonbra.javasteam.protobufs.steamclient.SteammessagesAuthSteamclie
 import `in`.dragonbra.javasteam.protobufs.steamclient.SteammessagesAuthSteamclient.CAuthentication_PollAuthSessionStatus_Response
 import `in`.dragonbra.javasteam.protobufs.steamclient.SteammessagesAuthSteamclient.EAuthSessionGuardType
 import `in`.dragonbra.javasteam.rpc.service.Authentication
+import `in`.dragonbra.javasteam.util.log.LogManager
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.future.asDeferred
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.future.future
 import java.util.concurrent.CompletableFuture
@@ -24,6 +24,7 @@ import java.util.concurrent.CompletableFuture
  * @param requestID Unique request ID to be presented by requestor at poll time.
  * @param allowedConfirmations Confirmation types that will be able to confirm the request.
  * @param pollingInterval Refresh interval with which requestor should call PollAuthSessionStatus.
+ * @param defaultScope Default coroutine scope used for authentication operations and polling.
  */
 @Suppress("MemberVisibilityCanBePrivate", "unused")
 open class AuthSession(
@@ -33,89 +34,85 @@ open class AuthSession(
     val requestID: ByteArray,
     var allowedConfirmations: List<CAuthentication_AllowedConfirmation>,
     val pollingInterval: Float,
+    val defaultScope: CoroutineScope,
 ) {
 
     companion object {
-        // private val logger = LogManager.getLogger(AuthSession::class.java)
+        private val logger = LogManager.getLogger(AuthSession::class.java)
     }
-
-    val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     init {
         allowedConfirmations = sortConfirmations(allowedConfirmations)
     }
 
     /**
-     * Java Compat:
-     * Handle any 2-factor authentication, and if necessary poll for updates until authentication succeeds.
-     *
-     * @return An [AuthPollResult] containing tokens which can be used to log in to Steam.
-     */
-    @Throws(AuthenticationException::class)
-    fun pollingWaitForResultFuture(): CompletableFuture<AuthPollResult> = scope.future { pollingWaitForResult() }
-
-    /**
      * Handle any 2-factor authentication, and if necessary poll for updates until authentication succeeds.
      * @return An [AuthPollResult] containing tokens which can be used to log in to Steam.
      */
     @Throws(AuthenticationException::class)
-    suspend fun pollingWaitForResult(): AuthPollResult {
-        var preferredConfirmation = allowedConfirmations.firstOrNull()
-            ?: throw AuthenticationException("There are no allowed confirmations")
+    @JvmOverloads
+    fun pollingWaitForResult(parentScope: CoroutineScope = defaultScope): CompletableFuture<AuthPollResult> =
+        parentScope.future {
+            var preferredConfirmation = allowedConfirmations.firstOrNull()
+                ?: throw AuthenticationException("There are no allowed confirmations")
 
-        if (preferredConfirmation.confirmationType == EAuthSessionGuardType.k_EAuthSessionGuardType_Unknown) {
-            throw AuthenticationException("There are no allowed confirmations")
-        }
+            if (preferredConfirmation.confirmationType == EAuthSessionGuardType.k_EAuthSessionGuardType_Unknown) {
+                throw AuthenticationException("There are no allowed confirmations")
+            }
 
-        // If an authenticator is provided and the device confirmation is available, allow consumers to choose whether they want to
-        // simply poll until confirmation is accepted, or whether they want to fall back to the next preferred confirmation type.
-        authenticator?.let { auth ->
-            if (preferredConfirmation.confirmationType == EAuthSessionGuardType.k_EAuthSessionGuardType_DeviceConfirmation) {
-                val prefersToPollForConfirmation = auth.acceptDeviceConfirmation().await()
+            // If an authenticator is provided and the device confirmation is available, allow consumers to choose whether they want to
+            // simply poll until confirmation is accepted, or whether they want to fall back to the next preferred confirmation type.
+            authenticator?.let { auth ->
+                if (preferredConfirmation.confirmationType == EAuthSessionGuardType.k_EAuthSessionGuardType_DeviceConfirmation) {
+                    val prefersToPollForConfirmation = auth.acceptDeviceConfirmation().asDeferred().await()
 
-                if (!prefersToPollForConfirmation) {
-                    if (allowedConfirmations.size <= 1) {
-                        throw AuthenticationException(
-                            "AcceptDeviceConfirmation returned false which indicates a fallback to another " +
-                                "confirmation type, but there are no other confirmation types available."
-                        )
+                    if (!prefersToPollForConfirmation) {
+                        if (allowedConfirmations.size <= 1) {
+                            throw AuthenticationException(
+                                "AcceptDeviceConfirmation returned false which indicates a fallback to another " +
+                                    "confirmation type, but there are no other confirmation types available."
+                            )
+                        }
+
+                        preferredConfirmation = allowedConfirmations[1]
                     }
-
-                    preferredConfirmation = allowedConfirmations[1]
                 }
             }
-        }
 
-        var pollLoop = false
-        when (preferredConfirmation.confirmationType) {
-            EAuthSessionGuardType.k_EAuthSessionGuardType_None -> Unit // No steam guard
-            EAuthSessionGuardType.k_EAuthSessionGuardType_EmailCode,
-            EAuthSessionGuardType.k_EAuthSessionGuardType_DeviceCode,
-            -> {
-                // 2-factor code from the authenticator app or sent to an email
-                handleCodeAuth(preferredConfirmation)
+            var pollLoop = false
+            when (preferredConfirmation.confirmationType) {
+                EAuthSessionGuardType.k_EAuthSessionGuardType_None -> Unit // No steam guard
+                EAuthSessionGuardType.k_EAuthSessionGuardType_EmailCode,
+                EAuthSessionGuardType.k_EAuthSessionGuardType_DeviceCode,
+                -> {
+                    // 2-factor code from the authenticator app or sent to an email
+                    handleCodeAuth(preferredConfirmation, parentScope)
+                }
+
+                EAuthSessionGuardType.k_EAuthSessionGuardType_DeviceConfirmation -> {
+                    // This is a prompt that appears in the Steam mobile app
+                    pollLoop = true
+                }
+                // SessionGuardType.k_EAuthSessionGuardType_EmailConfirmation -> Unit // Unknown
+                // SessionGuardType.k_EAuthSessionGuardType_MachineToken -> Unit // Unknown
+                else -> throw AuthenticationException(
+                    "Unsupported confirmation type ${preferredConfirmation.confirmationType}."
+                )
             }
 
-            EAuthSessionGuardType.k_EAuthSessionGuardType_DeviceConfirmation -> {
-                // This is a prompt that appears in the Steam mobile app
-                pollLoop = true
+            if (!pollLoop) {
+                val result = pollAuthSessionStatus(this).await()
+                result ?: throw AuthenticationException("Authentication failed", EResult.Fail)
+            } else {
+                pollDeviceConfirmation(this)
             }
-            // SessionGuardType.k_EAuthSessionGuardType_EmailConfirmation -> Unit // Unknown
-            // SessionGuardType.k_EAuthSessionGuardType_MachineToken -> Unit // Unknown
-            else -> throw AuthenticationException(
-                "Unsupported confirmation type ${preferredConfirmation.confirmationType}."
-            )
         }
-
-        return if (!pollLoop) {
-            pollAuthSessionStatus() ?: throw AuthenticationException("Authentication failed", EResult.Fail)
-        } else {
-            pollDeviceConfirmation()
-        }
-    }
 
     @Throws(AuthenticationException::class)
-    private suspend fun handleCodeAuth(preferredConfirmation: CAuthentication_AllowedConfirmation) {
+    private suspend fun handleCodeAuth(
+        preferredConfirmation: CAuthentication_AllowedConfirmation,
+        parentScope: CoroutineScope,
+    ) {
         val credentialsAuthSession = this as? CredentialsAuthSession
             ?: throw AuthenticationException(
                 "Got ${preferredConfirmation.confirmationType} confirmation type in a session " +
@@ -142,11 +139,11 @@ open class AuthSession(
                 val task = when (preferredConfirmation.confirmationType) {
                     EAuthSessionGuardType.k_EAuthSessionGuardType_EmailCode -> {
                         val msg = preferredConfirmation.associatedMessage
-                        authenticator.getEmailCode(msg, previousCodeWasIncorrect).await()
+                        authenticator.getEmailCode(msg, previousCodeWasIncorrect).asDeferred().await()
                     }
 
                     EAuthSessionGuardType.k_EAuthSessionGuardType_DeviceCode -> {
-                        authenticator.getDeviceCode(previousCodeWasIncorrect).await()
+                        authenticator.getDeviceCode(previousCodeWasIncorrect).asDeferred().await()
                     }
 
                     else -> throw AuthenticationException()
@@ -156,10 +153,11 @@ open class AuthSession(
                     throw AuthenticationException("No code was provided by the authenticator.")
                 }
 
-                credentialsAuthSession.sendSteamGuardCode(task, preferredConfirmation.confirmationType)
+                credentialsAuthSession.sendSteamGuardCode(task, preferredConfirmation.confirmationType, parentScope)
 
                 waitingForValidCode = false
             } catch (e: AuthenticationException) {
+                logger.error(e)
                 if (e.result == expectedInvalidCodeResult) {
                     previousCodeWasIncorrect = true
                 }
@@ -168,51 +166,42 @@ open class AuthSession(
     }
 
     @Throws(AuthenticationException::class)
-    private suspend fun pollDeviceConfirmation(): AuthPollResult {
+    private suspend fun pollDeviceConfirmation(parentScope: CoroutineScope): AuthPollResult {
         while (true) {
-            pollAuthSessionStatus()?.let { return it }
+            pollAuthSessionStatus(parentScope).await()?.let { return it }
             delay(pollingInterval.toLong())
         }
     }
 
     /**
-     * Java Compat:
      * Polls for authentication status once. Prefer using [pollingWaitForResult] instead.
      * @return An object containing tokens which can be used to log in to Steam, or null if not yet authenticated.
      * @throws AuthenticationException Thrown when polling fails.
      */
     @Throws(AuthenticationException::class)
-    fun pollAuthSessionStatusFuture(): CompletableFuture<AuthPollResult?> = scope.future {
-        pollAuthSessionStatus()
-    }
+    @JvmOverloads
+    fun pollAuthSessionStatus(parentScope: CoroutineScope = defaultScope): CompletableFuture<AuthPollResult?> =
+        parentScope.future {
+            val request = CAuthentication_PollAuthSessionStatus_Request.newBuilder().apply {
+                clientId = clientID
+                requestId = ByteString.copyFrom(requestID)
+            }
 
-    /**
-     * Polls for authentication status once. Prefer using [pollingWaitForResult] instead.
-     * @return An object containing tokens which can be used to log in to Steam, or null if not yet authenticated.
-     * @throws AuthenticationException Thrown when polling fails.
-     */
-    @Throws(AuthenticationException::class)
-    suspend fun pollAuthSessionStatus(): AuthPollResult? {
-        val request = CAuthentication_PollAuthSessionStatus_Request.newBuilder().apply {
-            clientId = clientID
-            requestId = ByteString.copyFrom(requestID)
+            val result = authentication.authenticationService.pollAuthSessionStatus(request.build()).await()
+
+            // eResult can be Expired, FileNotFound, Fail
+            if (result.result != EResult.OK) {
+                throw AuthenticationException("Failed to poll status", result.result)
+            }
+
+            handlePollAuthSessionStatusResponse(result.body)
+
+            if (result.body.refreshToken.isNotEmpty()) {
+                return@future AuthPollResult(result.body)
+            }
+
+            return@future null
         }
-
-        val result = authentication.authenticationService.pollAuthSessionStatus(request.build()).await()
-
-        // eResult can be Expired, FileNotFound, Fail
-        if (result.result != EResult.OK) {
-            throw AuthenticationException("Failed to poll status", result.result)
-        }
-
-        handlePollAuthSessionStatusResponse(result.body)
-
-        if (result.body.refreshToken.isNotEmpty()) {
-            return AuthPollResult(result.body)
-        }
-
-        return null
-    }
 
     internal open fun handlePollAuthSessionStatusResponse(response: CAuthentication_PollAuthSessionStatus_Response.Builder) {
         if (response.newClientId != 0L) {

--- a/src/main/java/in/dragonbra/javasteam/steam/authentication/AuthSession.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/authentication/AuthSession.kt
@@ -101,8 +101,8 @@ open class AuthSession(
             }
 
             if (!pollLoop) {
-                val result = pollAuthSessionStatus(this).await()
-                result ?: throw AuthenticationException("Authentication failed", EResult.Fail)
+                pollAuthSessionStatus(this).await()
+                    ?: throw AuthenticationException("Authentication failed while polling", EResult.Fail)
             } else {
                 pollDeviceConfirmation(this)
             }
@@ -185,9 +185,9 @@ open class AuthSession(
             val request = CAuthentication_PollAuthSessionStatus_Request.newBuilder().apply {
                 clientId = clientID
                 requestId = ByteString.copyFrom(requestID)
-            }
+            }.build()
 
-            val result = authentication.authenticationService.pollAuthSessionStatus(request.build()).await()
+            val result = authentication.authenticationService.pollAuthSessionStatus(request).await()
 
             // eResult can be Expired, FileNotFound, Fail
             if (result.result != EResult.OK) {

--- a/src/main/java/in/dragonbra/javasteam/steam/authentication/CredentialsAuthSession.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/authentication/CredentialsAuthSession.kt
@@ -5,38 +5,33 @@ import `in`.dragonbra.javasteam.protobufs.steamclient.SteammessagesAuthSteamclie
 import `in`.dragonbra.javasteam.protobufs.steamclient.SteammessagesAuthSteamclient.CAuthentication_UpdateAuthSessionWithSteamGuardCode_Request
 import `in`.dragonbra.javasteam.protobufs.steamclient.SteammessagesAuthSteamclient.EAuthSessionGuardType
 import `in`.dragonbra.javasteam.types.SteamID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.future.future
+import java.util.concurrent.*
 
 /**
  * Credentials based authentication session.
  */
 @Suppress("unused")
-class CredentialsAuthSession(
+class CredentialsAuthSession @JvmOverloads constructor(
     authentication: SteamAuthentication,
     authenticator: IAuthenticator?,
     response: CAuthentication_BeginAuthSessionViaCredentials_Response.Builder,
+    defaultScope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
 ) : AuthSession(
     authentication = authentication,
     authenticator = authenticator,
     clientID = response.clientId,
     requestID = response.requestId.toByteArray(),
     allowedConfirmations = response.allowedConfirmationsList,
-    pollingInterval = response.interval
+    pollingInterval = response.interval,
+    defaultScope = defaultScope
 ) {
 
     // SteamID of the account logging in, will only be included if the credentials were correct.
     private val steamID: SteamID = SteamID(response.steamid)
-
-    /**
-     * Java Compat:
-     * Send Steam Guard code for this authentication session.
-     * @param code     The code.
-     * @param codeType Type of code.
-     * @throws AuthenticationException .
-     */
-    fun sendSteamGuardCodeFuture(code: String?, codeType: EAuthSessionGuardType?) = scope.future {
-        sendSteamGuardCode(code, codeType)
-    }
 
     /**
      * Send Steam Guard code for this authentication session.
@@ -45,16 +40,21 @@ class CredentialsAuthSession(
      * @throws AuthenticationException .
      */
     @Throws(AuthenticationException::class)
-    suspend fun sendSteamGuardCode(code: String?, codeType: EAuthSessionGuardType?) {
+    @JvmOverloads
+    fun sendSteamGuardCode(
+        code: String?,
+        codeType: EAuthSessionGuardType?,
+        parentScope: CoroutineScope = defaultScope,
+    ): CompletableFuture<Unit> = parentScope.future {
         val request = CAuthentication_UpdateAuthSessionWithSteamGuardCode_Request.newBuilder().apply {
             this.clientId = clientID
             this.steamid = steamID.convertToUInt64()
             this.code = code
             this.codeType = codeType
-        }
+        }.build()
 
         val response = authentication.authenticationService
-            .updateAuthSessionWithSteamGuardCode(request.build())
+            .updateAuthSessionWithSteamGuardCode(request)
             .await()
 
         // Observed results can be InvalidLoginAuthCode, TwoFactorCodeMismatch, Expired, DuplicateRequest.

--- a/src/main/java/in/dragonbra/javasteam/steam/authentication/QrAuthSession.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/authentication/QrAuthSession.kt
@@ -2,21 +2,26 @@ package `in`.dragonbra.javasteam.steam.authentication
 
 import `in`.dragonbra.javasteam.protobufs.steamclient.SteammessagesAuthSteamclient.CAuthentication_BeginAuthSessionViaQR_Response
 import `in`.dragonbra.javasteam.protobufs.steamclient.SteammessagesAuthSteamclient.CAuthentication_PollAuthSessionStatus_Response
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 
 /**
  * QR code based authentication session.
  */
-class QrAuthSession(
+class QrAuthSession @JvmOverloads constructor(
     authentication: SteamAuthentication,
     authenticator: IAuthenticator?,
     response: CAuthentication_BeginAuthSessionViaQR_Response.Builder,
+    defaultScope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
 ) : AuthSession(
     authentication = authentication,
     authenticator = authenticator,
     clientID = response.clientId,
     requestID = response.requestId.toByteArray(),
     allowedConfirmations = response.allowedConfirmationsList,
-    pollingInterval = response.interval
+    pollingInterval = response.interval,
+    defaultScope = defaultScope,
 ) {
 
     /**

--- a/src/main/java/in/dragonbra/javasteam/steam/authentication/SteamAuthentication.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/authentication/SteamAuthentication.kt
@@ -204,7 +204,7 @@ class SteamAuthentication(private val steamClient: SteamClient) {
         val response = authenticationService.beginAuthSessionViaCredentials(request.build()).await()
 
         if (response.result != EResult.OK) {
-            throw AuthenticationException("Authentication failed", response.result)
+            throw AuthenticationException("Authentication failed via credentials", response.result)
         }
 
         return@future CredentialsAuthSession(

--- a/src/main/java/in/dragonbra/javasteam/steam/cdn/Client.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/cdn/Client.kt
@@ -37,6 +37,9 @@ class Client(steamClient: SteamClient) : Closeable {
     private val defaultScope = CoroutineScope(Dispatchers.IO)
 
     companion object {
+
+        private val logger: Logger = LogManager.getLogger(Client::class.java)
+
         /**
          * Default timeout to use when making requests
          */
@@ -46,8 +49,6 @@ class Client(steamClient: SteamClient) : Closeable {
          * Default timeout to use when reading the response body
          */
         var responseBodyTimeout = 60000L
-
-        private val logger: Logger = LogManager.getLogger(Client::class.java)
 
         @JvmStatic
         @JvmOverloads

--- a/src/main/java/in/dragonbra/javasteam/steam/cdn/Client.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/cdn/Client.kt
@@ -145,34 +145,34 @@ class Client(steamClient: SteamClient) : Closeable {
                     logger.debug("Manifest response does not have Content-Length, falling back to unbuffered read.")
                 }
 
-                val inputStream = response.body.byteStream()
+                response.body.byteStream().use { inputStream ->
+                    ByteArrayOutputStream().use { bs ->
+                        val bytesRead = inputStream.copyTo(bs, contentLength ?: DEFAULT_BUFFER_SIZE)
 
-                ByteArrayOutputStream().use { bs ->
-                    val bytesRead = inputStream.copyTo(bs, contentLength ?: DEFAULT_BUFFER_SIZE)
+                        if (bytesRead != contentLength?.toLong()) {
+                            throw DataFormatException("Length mismatch after downloading depot manifest! (was $bytesRead, but should be $contentLength)")
+                        }
 
-                    if (bytesRead != contentLength?.toLong()) {
-                        throw DataFormatException("Length mismatch after downloading depot manifest! (was $bytesRead, but should be $contentLength)")
-                    }
+                        val contentBytes = bs.toByteArray()
 
-                    val contentBytes = bs.toByteArray()
-
-                    MemoryStream(contentBytes).use { ms ->
-                        ZipInputStream(ms).use { zip ->
-                            var entryCount = 0
-                            while (zip.nextEntry != null) {
-                                entryCount++
-                            }
-                            if (entryCount > 1) {
-                                logger.debug("Expected the zip to contain only one file")
+                        MemoryStream(contentBytes).use { ms ->
+                            ZipInputStream(ms).use { zip ->
+                                var entryCount = 0
+                                while (zip.nextEntry != null) {
+                                    entryCount++
+                                }
+                                if (entryCount > 1) {
+                                    logger.debug("Expected the zip to contain only one file")
+                                }
                             }
                         }
-                    }
 
-                    // Decompress the zipped manifest data
-                    MemoryStream(contentBytes).use { ms ->
-                        ZipInputStream(ms).use { zip ->
-                            zip.nextEntry
-                            DepotManifest.deserialize(zip)
+                        // Decompress the zipped manifest data
+                        MemoryStream(contentBytes).use { ms ->
+                            ZipInputStream(ms).use { zip ->
+                                zip.nextEntry
+                                DepotManifest.deserialize(zip)
+                            }
                         }
                     }
                 }

--- a/src/main/java/in/dragonbra/javasteam/steam/cdn/ClientPool.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/cdn/ClientPool.kt
@@ -65,7 +65,6 @@ class ClientPool(internal val steamClient: SteamClient, private val appId: Int, 
         while (isActive) {
             populatePoolEvent.await(1, TimeUnit.SECONDS)
 
-            @Suppress("UsePropertyAccessSyntax")
             if (availableServerEndpoints.size < SERVER_ENDPOINT_MIN_SIZE && steamClient.isConnected) {
                 val servers = fetchBootstrapServerList().await()
 

--- a/src/main/java/in/dragonbra/javasteam/steam/contentdownloader/ContentDownloader.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/contentdownloader/ContentDownloader.kt
@@ -64,7 +64,7 @@ class ContentDownloader(val steamClient: SteamClient) {
         parentScope: CoroutineScope,
     ): Deferred<Pair<EResult, ByteArray?>> = parentScope.async {
         val steamApps = steamClient.getHandler(SteamApps::class.java)
-        val callback = steamApps?.getDepotDecryptionKey(depotId, appId)?.toDeferred()?.await()
+        val callback = steamApps?.getDepotDecryptionKey(depotId, appId)?.await()
 
         return@async Pair(callback?.result ?: EResult.Fail, callback?.depotKey)
     }
@@ -112,7 +112,7 @@ class ContentDownloader(val steamClient: SteamClient) {
         parentScope: CoroutineScope,
     ): Deferred<PICSProductInfo?> = parentScope.async {
         val steamApps = steamClient.getHandler(SteamApps::class.java)
-        val callback = steamApps?.picsGetProductInfo(PICSRequest(appId))?.toDeferred()?.await()
+        val callback = steamApps?.picsGetProductInfo(PICSRequest(appId))?.await()
         val apps = callback?.results?.flatMap { (it as PICSProductInfoCallback).apps.values }
 
         if (apps.isNullOrEmpty()) {

--- a/src/main/java/in/dragonbra/javasteam/steam/contentdownloader/FileManifestProvider.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/contentdownloader/FileManifestProvider.kt
@@ -46,6 +46,7 @@ class FileManifestProvider(private val file: Path) : IManifestProvider {
         private val logger: Logger = LogManager.getLogger(FileManifestProvider::class.java)
 
         private fun getLatestEntryName(depotID: Int): String = "$depotID${File.separator}latest"
+
         private fun getEntryName(depotID: Int, manifestID: Long): String = "$depotID${File.separator}$manifestID.bin"
 
         private fun seekToEntry(zipStream: ZipInputStream, entryName: String): ZipEntry? {
@@ -83,13 +84,14 @@ class FileManifestProvider(private val file: Path) : IManifestProvider {
         }
 
         private fun zipUncompressed(zip: ZipOutputStream, entryName: String, bytes: ByteArray) {
-            val entry = ZipEntry(entryName)
-            entry.method = ZipEntry.STORED
-            entry.size = bytes.size.toLong()
-            entry.compressedSize = bytes.size.toLong()
-            entry.crc = CRC32().run {
-                update(bytes)
-                value
+            val entry = ZipEntry(entryName).apply {
+                method = ZipEntry.STORED
+                size = bytes.size.toLong()
+                compressedSize = bytes.size.toLong()
+                crc = CRC32().run {
+                    update(bytes)
+                    value
+                }
             }
 
             zip.putNextEntry(entry)

--- a/src/main/java/in/dragonbra/javasteam/steam/contentdownloader/MemoryManifestProvider.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/contentdownloader/MemoryManifestProvider.kt
@@ -9,6 +9,7 @@ import `in`.dragonbra.javasteam.types.DepotManifest
 class MemoryManifestProvider : IManifestProvider {
 
     private val depotManifests = mutableMapOf<Int, MutableMap<Long, DepotManifest>>()
+
     private val latestManifests = mutableMapOf<Int, Long>()
 
     override fun fetchManifest(depotID: Int, manifestID: Long): DepotManifest? =

--- a/src/main/java/in/dragonbra/javasteam/steam/discovery/MemoryServerListProvider.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/discovery/MemoryServerListProvider.kt
@@ -8,6 +8,7 @@ import java.time.Instant
 class MemoryServerListProvider : IServerListProvider {
 
     private var servers: List<ServerRecord> = listOf()
+
     private var lastUpdated: Instant = Instant.MIN
 
     /**

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamcloud/SteamCloud.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamcloud/SteamCloud.kt
@@ -147,7 +147,7 @@ class SteamCloud : ClientMsgHandler() {
             this.syncedChangeNumber = syncedChangeNumber
         }
 
-        val response = cloudService.getAppFileChangelist(request.build()).runBlock()
+        val response = cloudService.getAppFileChangelist(request.build()).await()
 
         AppFileChangeList(response.body)
     }
@@ -177,7 +177,7 @@ class SteamCloud : ClientMsgHandler() {
             this.forceProxy = forceProxy
         }
 
-        val response = cloudService.clientFileDownload(request.build()).runBlock()
+        val response = cloudService.clientFileDownload(request.build()).await()
 
         FileDownloadInfo(response.body)
     }
@@ -213,7 +213,7 @@ class SteamCloud : ClientMsgHandler() {
             this.appBuildId = appBuildId
         }
 
-        val response = cloudService.beginAppUploadBatch(request.build()).runBlock()
+        val response = cloudService.beginAppUploadBatch(request.build()).await()
 
         AppUploadBatchResponse(response.body)
     }
@@ -260,7 +260,7 @@ class SteamCloud : ClientMsgHandler() {
             this.uploadBatchId = uploadBatchId
         }
 
-        val response = cloudService.clientBeginFileUpload(request.build()).runBlock()
+        val response = cloudService.clientBeginFileUpload(request.build()).await()
 
         FileUploadInfo(response.body)
     }
@@ -290,7 +290,7 @@ class SteamCloud : ClientMsgHandler() {
             this.filename = filename
         }
 
-        val response = cloudService.clientCommitFileUpload(request.build()).runBlock()
+        val response = cloudService.clientCommitFileUpload(request.build()).await()
         response.body.fileCommitted
     }
 
@@ -316,7 +316,7 @@ class SteamCloud : ClientMsgHandler() {
             this.batchEresult = batchEResult.code()
         }
 
-        cloudService.completeAppUploadBatchBlocking(request.build()).runBlock()
+        cloudService.completeAppUploadBatchBlocking(request.build()).await()
     }
 
     /**
@@ -439,7 +439,7 @@ class SteamCloud : ClientMsgHandler() {
             this.deviceType = deviceType.number
         }
 
-        val response = cloudService.signalAppLaunchIntent(request.build()).runBlock()
+        val response = cloudService.signalAppLaunchIntent(request.build()).await()
 
         response.body.pendingRemoteOperationsList.map { PendingRemoteOperation(it) }
     }

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamcontent/SteamContent.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamcontent/SteamContent.kt
@@ -42,7 +42,7 @@ class SteamContent : ClientMsgHandler() {
             maxNumServers?.let { this.maxServers = it }
         }.build()
 
-        val message = contentService.getServersForSteamPipe(request).toDeferred().await()
+        val message = contentService.getServersForSteamPipe(request).await()
         val response = message.body.build()
 
         return@async ContentServerDirectoryService.convertServerList(response)
@@ -86,7 +86,7 @@ class SteamContent : ClientMsgHandler() {
             localBranchPasswordHash?.let { this.branchPasswordHash = it }
         }.build()
 
-        val message = contentService.getManifestRequestCode(request).toDeferred().await()
+        val message = contentService.getManifestRequestCode(request).await()
         val response = message.body.build()
 
         return@async response.manifestRequestCode.toULong()
@@ -113,7 +113,7 @@ class SteamContent : ClientMsgHandler() {
             this.hostName = hostName
         }.build()
 
-        val message = contentService.getCDNAuthToken(request).toDeferred().await()
+        val message = contentService.getCDNAuthToken(request).await()
 
         return@async AuthToken(message)
     }

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamcontent/SteamContent.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamcontent/SteamContent.kt
@@ -55,7 +55,7 @@ class SteamContent : ClientMsgHandler() {
      * @param appId The AppID parent of the DepotID.
      * @param manifestId The ManifestID that will be downloaded.
      * @param branch The branch name this manifest belongs to.
-     * @param branchPasswordHash The branch password. TODO: how is it hashed?
+     * @param branchPasswordHash The branch password. TODO: (SK) how is it hashed?
      * @return Returns the manifest request code, it may be zero if it was not granted.
      */
     fun getManifestRequestCode(

--- a/src/main/java/in/dragonbra/javasteam/steam/steamclient/AsyncJobManager.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/steamclient/AsyncJobManager.kt
@@ -14,11 +14,13 @@ import java.util.concurrent.ConcurrentMap
  */
 class AsyncJobManager {
 
+    companion object {
+        private val logger = LogManager.getLogger(AsyncJobManager::class.java)
+    }
+
     val asyncJobs: ConcurrentMap<JobID, AsyncJob> = ConcurrentHashMap()
 
     private val jobTimeoutFunc: ScheduledFunction = ScheduledFunction(this::cancelTimedOutJobs, 1000)
-
-    private val logger = LogManager.getLogger(AsyncJobManager::class.java)
 
     /**
      * Tracks a job with this manager.

--- a/src/main/java/in/dragonbra/javasteam/steam/steamclient/SteamClient.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/steamclient/SteamClient.kt
@@ -133,6 +133,15 @@ class SteamClient @JvmOverloads constructor(
      */
     @Suppress("UNCHECKED_CAST")
     fun <T : ClientMsgHandler> getHandler(type: Class<T>): T? = handlers[type] as T?
+
+    /**
+     * Kotlin Helper:
+     * Returns a registered handler.
+     *
+     * @param T  The type of the handler to cast to. Must derive from ClientMsgHandler.
+     * @return A registered handler on success, or null if the handler could not be found.
+     */
+    inline fun <reified T : ClientMsgHandler> getHandler(): T? = getHandler(T::class.java)
     //endregion
 
     //region Callbacks

--- a/src/main/java/in/dragonbra/javasteam/steam/steamclient/SteamClient.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/steamclient/SteamClient.kt
@@ -27,7 +27,9 @@ import `in`.dragonbra.javasteam.types.AsyncJob
 import `in`.dragonbra.javasteam.types.JobID
 import `in`.dragonbra.javasteam.util.log.LogManager
 import `in`.dragonbra.javasteam.util.log.Logger
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
@@ -44,9 +46,8 @@ import java.util.concurrent.atomic.AtomicLong
 @Suppress("unused")
 class SteamClient @JvmOverloads constructor(
     configuration: SteamConfiguration? = SteamConfiguration.createDefault(),
+    internal val defaultScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob()),
 ) : CMClient(configuration) {
-
-    // private val clientScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 
     private val handlers = HashMap<Class<out ClientMsgHandler>, ClientMsgHandler>(HANDLERS_COUNT)
 

--- a/src/main/java/in/dragonbra/javasteam/steam/steamclient/callbackmgr/CallbackManager.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/steamclient/callbackmgr/CallbackManager.kt
@@ -46,6 +46,7 @@ class CallbackManager(private val steamClient: SteamClient) {
      * @param timeout The length of time to block.
      * @return true if a callback has been run, false otherwise.
      */
+    // TODO: Add Kotlin coroutines version.
     fun runWaitCallbacks(timeout: Long): Boolean {
         val call = steamClient.waitForCallback(timeout) ?: return false
 

--- a/src/main/java/in/dragonbra/javasteam/steam/webapi/WebAPI.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/webapi/WebAPI.java
@@ -266,7 +266,7 @@ public class WebAPI {
     private KeyValue parseResponse(Response response) {
         KeyValue kv = new KeyValue();
 
-        try (InputStream is = response.body().byteStream()) {
+        try (var is = response.body().byteStream()) {
             kv.readAsText(is);
         } catch (Exception e) {
             throw new IllegalStateException("An internal error occurred when attempting to parse the response from the WebAPI server. This can indicate a change in the VDF format.", e);

--- a/src/main/java/in/dragonbra/javasteam/types/AsyncJob.kt
+++ b/src/main/java/in/dragonbra/javasteam/types/AsyncJob.kt
@@ -29,7 +29,6 @@ abstract class AsyncJob(val client: SteamClient, val jobID: JobID) {
     abstract fun setFailed(dueToRemoteFailure: Boolean)
 
     fun heartbeat() {
-        println("heartbeat")
         timeout += 10000
     }
 }

--- a/src/main/java/in/dragonbra/javasteam/types/AsyncJobMultiple.kt
+++ b/src/main/java/in/dragonbra/javasteam/types/AsyncJobMultiple.kt
@@ -4,6 +4,7 @@ import `in`.dragonbra.javasteam.steam.steamclient.AsyncJobFailedException
 import `in`.dragonbra.javasteam.steam.steamclient.SteamClient
 import `in`.dragonbra.javasteam.steam.steamclient.callbackmgr.CallbackMsg
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.future.await
 import java.util.*
 import java.util.concurrent.CompletableFuture
 
@@ -36,7 +37,7 @@ class AsyncJobMultiple<T : CallbackMsg>(
 
     fun toFuture(): CompletableFuture<ResultSet> = future
 
-    fun await(): ResultSet = toFuture().get()
+    suspend fun await(): ResultSet = future.await()
 
     @Suppress("unused")
     @Throws(CancellationException::class)

--- a/src/main/java/in/dragonbra/javasteam/types/AsyncJobMultiple.kt
+++ b/src/main/java/in/dragonbra/javasteam/types/AsyncJobMultiple.kt
@@ -3,8 +3,9 @@ package `in`.dragonbra.javasteam.types
 import `in`.dragonbra.javasteam.steam.steamclient.AsyncJobFailedException
 import `in`.dragonbra.javasteam.steam.steamclient.SteamClient
 import `in`.dragonbra.javasteam.steam.steamclient.callbackmgr.CallbackMsg
-import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CancellationException
 import java.util.*
+import java.util.concurrent.CompletableFuture
 
 /**
  * @author Lossy
@@ -22,7 +23,7 @@ class AsyncJobMultiple<T : CallbackMsg>(
         var results: List<CallbackMsg> = listOf(),
     )
 
-    private val tcs = CompletableDeferred<ResultSet>()
+    private val future = CompletableFuture<ResultSet>()
 
     private val results = mutableListOf<T>()
 
@@ -30,9 +31,16 @@ class AsyncJobMultiple<T : CallbackMsg>(
         registerJob(client)
     }
 
-    fun toDeferred(): CompletableDeferred<ResultSet> = tcs
+    @Deprecated("Use toFuture() instead", ReplaceWith("toFuture()"))
+    fun toDeferred(): CompletableFuture<ResultSet> = toFuture()
 
-    suspend fun await(): ResultSet = toDeferred().await()
+    fun toFuture(): CompletableFuture<ResultSet> = future
+
+    fun await(): ResultSet = toFuture().get()
+
+    @Suppress("unused")
+    @Throws(CancellationException::class)
+    fun runBlock(): ResultSet = toFuture().get()
 
     override fun addResult(callback: CallbackMsg): Boolean {
         @Suppress("UNCHECKED_CAST")
@@ -42,7 +50,7 @@ class AsyncJobMultiple<T : CallbackMsg>(
         results.add(callbackMsg)
 
         return if (finishCondition(callbackMsg) == true) {
-            tcs.complete(ResultSet(complete = true, failed = false, results = Collections.unmodifiableList(results)))
+            future.complete(ResultSet(complete = true, failed = false, results = Collections.unmodifiableList(results)))
             true
         } else {
             heartbeat()
@@ -55,15 +63,14 @@ class AsyncJobMultiple<T : CallbackMsg>(
             // if we have zero callbacks in our result set, we cancel this task
             if (dueToRemoteFailure) {
                 // if we're canceling with a remote failure, post a job failure exception
-                tcs.completeExceptionally(AsyncJobFailedException())
+                future.completeExceptionally(AsyncJobFailedException())
             } else {
                 // otherwise, normal task cancellation for timeouts
-                tcs.cancel()
+                future.cancel(true)
             }
         } else {
             val resultSet = ResultSet(false, dueToRemoteFailure, Collections.unmodifiableList(results))
-
-            tcs.complete(resultSet)
+            future.complete(resultSet)
         }
     }
 }

--- a/src/main/java/in/dragonbra/javasteam/types/AsyncJobMultiple.kt
+++ b/src/main/java/in/dragonbra/javasteam/types/AsyncJobMultiple.kt
@@ -32,6 +32,8 @@ class AsyncJobMultiple<T : CallbackMsg>(
 
     fun toDeferred(): CompletableDeferred<ResultSet> = tcs
 
+    suspend fun await(): ResultSet = toDeferred().await()
+
     override fun addResult(callback: CallbackMsg): Boolean {
         @Suppress("UNCHECKED_CAST")
         val callbackMsg = callback as T

--- a/src/main/java/in/dragonbra/javasteam/types/AsyncJobSingle.kt
+++ b/src/main/java/in/dragonbra/javasteam/types/AsyncJobSingle.kt
@@ -13,6 +13,7 @@ import kotlin.jvm.Throws
  * @since 2023-03-17
  */
 class AsyncJobSingle<T : CallbackMsg>(client: SteamClient, jobId: JobID) : AsyncJob(client, jobId) {
+
     private val tcs = CompletableDeferred<T>()
 
     init {
@@ -20,6 +21,8 @@ class AsyncJobSingle<T : CallbackMsg>(client: SteamClient, jobId: JobID) : Async
     }
 
     fun toDeferred(): CompletableDeferred<T> = tcs
+
+    suspend fun await(): T = toDeferred().await()
 
     @Throws(CancellationException::class)
     fun runBlock(): T = runBlocking { toDeferred().await() }

--- a/src/main/java/in/dragonbra/javasteam/types/AsyncJobSingle.kt
+++ b/src/main/java/in/dragonbra/javasteam/types/AsyncJobSingle.kt
@@ -4,9 +4,8 @@ import `in`.dragonbra.javasteam.steam.steamclient.AsyncJobFailedException
 import `in`.dragonbra.javasteam.steam.steamclient.SteamClient
 import `in`.dragonbra.javasteam.steam.steamclient.callbackmgr.CallbackMsg
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.runBlocking
-import kotlin.jvm.Throws
+import kotlinx.coroutines.future.await
+import java.util.concurrent.*
 
 /**
  * @author Lossy
@@ -14,23 +13,27 @@ import kotlin.jvm.Throws
  */
 class AsyncJobSingle<T : CallbackMsg>(client: SteamClient, jobId: JobID) : AsyncJob(client, jobId) {
 
-    private val tcs = CompletableDeferred<T>()
+    private val future = CompletableFuture<T>()
 
     init {
         registerJob(client)
     }
 
-    fun toDeferred(): CompletableDeferred<T> = tcs
+    @Deprecated("Use toFuture() instead", ReplaceWith("toFuture()"))
+    fun toDeferred(): CompletableFuture<T> = toFuture()
 
-    suspend fun await(): T = toDeferred().await()
+    fun toFuture(): CompletableFuture<T> = future
 
+    suspend fun await(): T = future.await()
+
+    @Suppress("unused")
     @Throws(CancellationException::class)
-    fun runBlock(): T = runBlocking { toDeferred().await() }
+    fun runBlock(): T = toFuture().get()
 
     override fun addResult(callback: CallbackMsg): Boolean {
         // we're complete with just this callback
         @Suppress("UNCHECKED_CAST")
-        tcs.complete(callback as T)
+        future.complete(callback as T)
 
         // inform steamclient that this job wishes to be removed from tracking since
         // we've received the single callback we were waiting for
@@ -39,11 +42,11 @@ class AsyncJobSingle<T : CallbackMsg>(client: SteamClient, jobId: JobID) : Async
 
     override fun setFailed(dueToRemoteFailure: Boolean) {
         if (dueToRemoteFailure) {
-            // if steam informs us of a remote failure, we cancel with our exception
-            tcs.completeExceptionally(AsyncJobFailedException())
+            // if steam informs us of a remote failure, we complete with exception
+            future.completeExceptionally(AsyncJobFailedException())
         } else {
-            // if we time out, we trigger a normal cancellation
-            tcs.cancel()
+            // if we time out, we cancel the future
+            future.cancel(true)
         }
     }
 }

--- a/src/main/java/in/dragonbra/javasteam/types/DepotManifest.kt
+++ b/src/main/java/in/dragonbra/javasteam/types/DepotManifest.kt
@@ -211,7 +211,7 @@ class DepotManifest {
         }
 
         // Sort file entries alphabetically because that's what Steam does
-        // TODO: Doesn't match Steam sorting if there are non-ASCII names present
+        // TODO: (SK) Doesn't match Steam sorting if there are non-ASCII names present
         files.sortWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.fileName })
 
         filenamesEncrypted = false
@@ -275,8 +275,8 @@ class DepotManifest {
         }
 
         if (payload != null && metadata != null && signature != null) {
-            parseProtobufManifestMetadata(metadata)
-            parseProtobufManifestPayload(payload)
+            parseProtobufManifestMetadata(metadata!!)
+            parseProtobufManifestPayload(payload!!)
         } else {
             throw NoSuchElementException("Missing ContentManifest sections required for parsing depot manifest")
         }

--- a/src/main/java/in/dragonbra/javasteam/util/HardwareUtils.java
+++ b/src/main/java/in/dragonbra/javasteam/util/HardwareUtils.java
@@ -56,14 +56,14 @@ public class HardwareUtils {
             return null;
         }
 
-        OutputStream os = process.getOutputStream();
+        var os = process.getOutputStream();
 
         try {
             os.close();
         } catch (IOException ignored) {
         }
 
-        try (Scanner sc = new Scanner(process.getInputStream())) {
+        try (var sc = new Scanner(process.getInputStream())) {
             while (sc.hasNext()) {
                 String next = sc.next();
                 if ("SerialNumber".equals(next)) {
@@ -88,7 +88,7 @@ public class HardwareUtils {
             return null;
         }
 
-        OutputStream os = process.getOutputStream();
+        var os = process.getOutputStream();
 
         try {
             os.close();
@@ -97,7 +97,7 @@ public class HardwareUtils {
 
         String line;
         String marker = "Serial Number";
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+        try (var br = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
             while ((line = br.readLine()) != null) {
                 if (line.contains(marker)) {
                     sn = line.split(":")[1].trim();
@@ -131,7 +131,7 @@ public class HardwareUtils {
             return null;
         }
 
-        OutputStream os = process.getOutputStream();
+        var os = process.getOutputStream();
 
         try {
             os.close();
@@ -148,7 +148,7 @@ public class HardwareUtils {
         String line;
         String marker = "Serial Number:";
 
-        try (BufferedReader br = read("dmidecode -t system")) {
+        try (var br = read("dmidecode -t system")) {
             if (br == null) {
                 return null;
             }
@@ -172,7 +172,7 @@ public class HardwareUtils {
         String line;
         String marker = "system.hardware.serial =";
 
-        try (BufferedReader br = read("lshal")) {
+        try (var br = read("lshal")) {
             if (br == null) {
                 return null;
             }
@@ -211,7 +211,9 @@ public class HardwareUtils {
     private static String getDeviceName() {
         try {
             Process process = Runtime.getRuntime().exec("hostname");
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+
+            try (var inputStreamReader = new InputStreamReader(process.getInputStream());
+                 var reader = new BufferedReader(inputStreamReader)) {
                 return reader.readLine().trim();
             }
         } catch (IOException e) {

--- a/src/main/java/in/dragonbra/javasteam/util/HardwareUtils.java
+++ b/src/main/java/in/dragonbra/javasteam/util/HardwareUtils.java
@@ -49,6 +49,7 @@ public class HardwareUtils {
 
         Runtime runtime = Runtime.getRuntime();
         Process process;
+
         try {
             process = runtime.exec(new String[]{"wmic", "bios", "get", "serialnumber"});
         } catch (IOException e) {
@@ -80,6 +81,7 @@ public class HardwareUtils {
 
         Runtime runtime = Runtime.getRuntime();
         Process process;
+
         try {
             process = runtime.exec(new String[]{"/usr/sbin/system_profiler", "SPHardwareDataType"});
         } catch (IOException e) {
@@ -216,7 +218,7 @@ public class HardwareUtils {
             return null;
         }
     }
-    
+
     private static String getAndroidDeviceName() {
         String manufacturer = getAndroidSystemProperty("ro.product.manufacturer");
         String model = getAndroidSystemProperty("ro.product.model");

--- a/src/main/java/in/dragonbra/javasteam/util/ZipUtil.kt
+++ b/src/main/java/in/dragonbra/javasteam/util/ZipUtil.kt
@@ -8,8 +8,8 @@ object ZipUtil {
 
     fun decompress(ms: MemoryStream, destination: ByteArray, verifyChecksum: Boolean = true): Int {
         ZipInputStream(ms, Charsets.UTF_8).use { zip ->
-            val entry =
-                zip.nextEntry ?: throw IllegalArgumentException("Did not find any zip entries in the given stream")
+            val entry = zip.nextEntry
+                ?: throw IllegalArgumentException("Did not find any zip entries in the given stream")
 
             val sizeDecompressed = entry.size.toInt()
 

--- a/src/main/java/in/dragonbra/javasteam/util/crypto/RSACrypto.java
+++ b/src/main/java/in/dragonbra/javasteam/util/crypto/RSACrypto.java
@@ -41,7 +41,7 @@ public class RSACrypto {
             final BigInteger[] keys = keyParser.parseRSAPublicKey();
             init(keys[0], keys[1]);
         } catch (final BerDecodeException e) {
-            e.printStackTrace();
+            logger.error(e);
         }
     }
 
@@ -55,7 +55,7 @@ public class RSACrypto {
             cipher = Cipher.getInstance("RSA/None/OAEPWithSHA1AndMGF1Padding", CryptoHelper.SEC_PROV);
             cipher.init(Cipher.ENCRYPT_MODE, rsaKey);
         } catch (final NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException | InvalidKeySpecException
-                | NoSuchProviderException e) {
+                       | NoSuchProviderException e) {
             logger.debug(e);
         }
     }
@@ -66,6 +66,7 @@ public class RSACrypto {
         } catch (final IllegalBlockSizeException | BadPaddingException e) {
             logger.debug(e);
         }
+
         return null;
     }
 }

--- a/src/test/java/in/dragonbra/javasteam/steam/cdn/CDNClientTest.java
+++ b/src/test/java/in/dragonbra/javasteam/steam/cdn/CDNClientTest.java
@@ -28,7 +28,7 @@ public class CDNClientTest {
                     .protocol(Protocol.HTTP_1_1)
                     .message("I'm a teapot")
                     .request(chain.request())
-                    .body(ResponseBody.create(null, new byte[0]))
+                    .body(ResponseBody.create(new byte[0], null))
                     .build();
         }
     }

--- a/src/test/java/in/dragonbra/javasteam/steam/handlers/steamfriends/SteamFriendsTest.java
+++ b/src/test/java/in/dragonbra/javasteam/steam/handlers/steamfriends/SteamFriendsTest.java
@@ -387,6 +387,7 @@ public class SteamFriendsTest extends HandlerTestBase<SteamFriends> {
         ChatMemberInfoCallback callback = verifyCallback();
 
         assertEquals(new SteamID(123), callback.getChatRoomID());
+        assertEquals(EChatInfoType.StateChange, callback.getType());
     }
 
     @Test


### PR DESCRIPTION
### Description
This one got a bit large trying to optimize the library. 

Changes regarding resource closing: 
- Generated steam language files.
- `KeyValue` tryReadAsBinaryCore and readFileAsText
- `AClientMsgProtobuf` deserialise
- `ClientGCMsg` serialize and deserialise
- `ClientGCMsgProtobuf` serialize and deserialise
- `ClientMsg` serialize and deserialise
- `ClientMsgProtobuf` serialize and deserialise
- `Msg` serialize and deserialise
- `CMClient` getPacketMsg
- `cdn.Client` downloadManifest

Changes with Authentication: 
- Removed `compat` methods, folding them with the main method which returns a `CompletableFuture`
- `beginAuthSessionViaQR` and `beginAuthSessionViaCredentials` return a `CompletableFuture`

Other Changes:
- `AsyncJobSingle` and `AsyncJobMultiple` use CompletableFuture instead of CompletableDeferred.
- Add helpers for the CompletableFuture for `AsyncJobSingle` and `AsyncJobMultiple`.
- Add addtional assertion in `SteamFriendsTest`.
- Add log to `RSACrypto` exception to elimate warning.
- Add inline function for `SteamClient.getHelper()`.
- Removed stray "heartbeat" print line in `AsyncJob`.
- Removed deprecation in `CDNClientTest`.
- `AsyncJobTest` and `SteamFriendsTest` updates.
- Updated sample 000 showing how to close subscriptions to elimiate `try'-with-resources statement` warning. 
- Updated other samples with the above changes. 
- Code formatting.

Any internal suspending/future code should be able to await instead of blocking, giving control higher up whether to block or run aync. 

Library also ran with two accounts via android. One with device auth and the other email auth. 

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
