### PR TITLE
Fix race condition

### DIFF
--- a/src/main/java/in/dragonbra/javasteam/steam/authentication/UserConsoleAuthenticator.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/authentication/UserConsoleAuthenticator.kt
@@ -12,7 +12,7 @@ import java.util.concurrent.CompletableFuture
  */
 class UserConsoleAuthenticator : IAuthenticator {
 
-    override fun getDeviceCode(previousCodeWasIncorrect: Boolean): CompletableFuture<String> {
+    override fun getDeviceCode(previousCodeWasIncorrect: Boolean): CompletableFuture<String> = CompletableFuture.supplyAsync {
         if (previousCodeWasIncorrect) {
             println("The previous 2-factor auth code you have provided is incorrect.")
         }
@@ -23,26 +23,24 @@ class UserConsoleAuthenticator : IAuthenticator {
             code = readln().trim()
         } while (Strings.isNullOrEmpty(code))
 
-        return CompletableFuture.completedFuture(code)
+        code
     }
 
-    override fun getEmailCode(email: String?, previousCodeWasIncorrect: Boolean): CompletableFuture<String> {
+    override fun getEmailCode(email: String?, previousCodeWasIncorrect: Boolean): CompletableFuture<String> = CompletableFuture.supplyAsync {
         if (previousCodeWasIncorrect) {
             println("The previous 2-factor auth code you have provided is incorrect.")
         }
-
         var code: String
         do {
             print("STEAM GUARD! Please enter the auth code sent to the email at $email: ")
             code = readln().trim()
         } while (Strings.isNullOrEmpty(code))
 
-        return CompletableFuture.completedFuture(code)
+        code
     }
 
-    override fun acceptDeviceConfirmation(): CompletableFuture<Boolean> {
+    override fun acceptDeviceConfirmation(): CompletableFuture<Boolean> = CompletableFuture.supplyAsync {
         println("STEAM GUARD! Use the Steam Mobile App to confirm your sign in...")
-
-        return CompletableFuture.completedFuture(true)
+        true
     }
 }

--- a/src/main/java/in/dragonbra/javasteam/steam/steamclient/SteamClient.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/steamclient/SteamClient.kt
@@ -46,7 +46,7 @@ import java.util.concurrent.atomic.AtomicLong
 @Suppress("unused")
 class SteamClient @JvmOverloads constructor(
     configuration: SteamConfiguration? = SteamConfiguration.createDefault(),
-    internal val defaultScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob()),
+    internal val defaultScope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
 ) : CMClient(configuration) {
 
     private val handlers = HashMap<Class<out ClientMsgHandler>, ClientMsgHandler>(HANDLERS_COUNT)


### PR DESCRIPTION
### Description
I inadvertently caused a race condition from the recent Steam Authentication changes recently. 

- When calling `sendSteamGuardCode()` after typing in your 5 digit two factor code, a race condition was created while trying to send the data to authenticate with steam. After entering the information, the authentication immediately polled for the result without giving the client time to send that auth data for a proper poll response. 
- SteamClient's defaultScope should use the IO dispatcher instead of default.

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
