### PR TITLE
Fix values that may end up null in Enum.from()

### DIFF
--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamapps/License.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamapps/License.kt
@@ -45,7 +45,7 @@ class License(license: CMsgClientLicenseList.License) {
     /**
      * Gets the payment method used when the license was created.
      */
-    val paymentMethod: EPaymentMethod = EPaymentMethod.from(license.paymentMethod)
+    val paymentMethod: EPaymentMethod? = EPaymentMethod.from(license.paymentMethod)
 
     /**
      * Gets the license flags.
@@ -60,7 +60,7 @@ class License(license: CMsgClientLicenseList.License) {
     /**
      * Gets the type of the license.
      */
-    val licenseType: ELicenseType = ELicenseType.from(license.licenseType)
+    val licenseType: ELicenseType? = ELicenseType.from(license.licenseType)
 
     /**
      * Gets the territory code of the license.

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamapps/callback/PurchaseResponseCallback.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamapps/callback/PurchaseResponseCallback.kt
@@ -28,7 +28,7 @@ class PurchaseResponseCallback(packetMsg: IPacketMsg) : CallbackMsg() {
     /**
      * Gets Purchase result of the operation
      */
-    val purchaseResultDetail: EPurchaseResultDetail
+    val purchaseResultDetail: EPurchaseResultDetail?
 
     /**
      * Gets Purchase receipt of the operation

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamcloud/PendingRemoteOperation.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamcloud/PendingRemoteOperation.kt
@@ -9,6 +9,6 @@ class PendingRemoteOperation(operation: CCloud_PendingRemoteOperation) {
     val machineName: String = operation.machineName
     val clientId: Long = operation.clientId
     val timeLastUpdated: Int = operation.timeLastUpdated
-    val osType: EOSType = EOSType.from(operation.osType)
+    val osType: EOSType = EOSType.from(operation.osType) ?: EOSType.Unknown
     val deviceType: Int = operation.deviceType
 }

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamfriends/SteamFriends.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamfriends/SteamFriends.kt
@@ -327,7 +327,7 @@ class SteamFriends : ClientMsgHandler() {
      * @param steamID The clan steamid.
      * @return The relationship of the clan to the local user.
      */
-    fun getClanRelationship(steamID: SteamID): EClanRelationship = cache.clans.getAccount(steamID).relationship
+    fun getClanRelationship(steamID: SteamID): EClanRelationship? = cache.clans.getAccount(steamID).relationship
 
     /**
      * Gets an SHA-1 hash representing the clan's avatar.
@@ -754,7 +754,7 @@ class SteamFriends : ClientMsgHandler() {
 
                 if (EClientPersonaStateFlag.Presence in flags) {
                     cacheFriend.avatarHash = friend.avatarHash.toByteArray()
-                    cacheFriend.personaState = EPersonaState.from(friend.personaState)
+                    cacheFriend.personaState = EPersonaState.from(friend.personaState) ?: EPersonaState.Offline
                     cacheFriend.personaStateFlags = EPersonaStateFlag.from(friend.personaStateFlags)
                 }
 

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamfriends/SteamFriends.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamfriends/SteamFriends.kt
@@ -831,7 +831,7 @@ class SteamFriends : ClientMsgHandler() {
             } else if (friendID.isClanAccount) {
                 val clan = cache.clans.getAccount(friendID)
 
-                clan.relationship = EClanRelationship.from(friendObj.efriendrelationship)
+                clan.relationship = EClanRelationship.from(friendObj.efriendrelationship) ?: EClanRelationship.None
 
                 if (clanList.contains(friendID)) {
                     // mark clans we were removed/kicked from

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamfriends/cache/FriendCache.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamfriends/cache/FriendCache.kt
@@ -25,7 +25,7 @@ data class User(
 ) : Account()
 
 class Clan(
-    var relationship: EClanRelationship? = EClanRelationship.None,
+    var relationship: EClanRelationship = EClanRelationship.None,
 ) : Account()
 
 class AccountList<T : Account>(private val clazz: Class<T>) : ConcurrentHashMap<SteamID, T>() {

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamfriends/cache/FriendCache.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamfriends/cache/FriendCache.kt
@@ -25,7 +25,7 @@ data class User(
 ) : Account()
 
 class Clan(
-    var relationship: EClanRelationship = EClanRelationship.None,
+    var relationship: EClanRelationship? = EClanRelationship.None,
 ) : Account()
 
 class AccountList<T : Account>(private val clazz: Class<T>) : ConcurrentHashMap<SteamID, T>() {

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamfriends/callback/FriendMsgCallback.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamfriends/callback/FriendMsgCallback.kt
@@ -22,7 +22,7 @@ class FriendMsgCallback(packetMsg: IPacketMsg) : CallbackMsg() {
     /**
      * Gets the chat entry type.
      */
-    val entryType: EChatEntryType
+    val entryType: EChatEntryType?
 
     /**
      * Gets a value indicating whether this message is from a limited account.

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamfriends/callback/FriendMsgEchoCallback.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamfriends/callback/FriendMsgEchoCallback.kt
@@ -21,7 +21,7 @@ class FriendMsgEchoCallback(packetMsg: IPacketMsg) : CallbackMsg() {
     /**
      * Gets the chat entry type.
      */
-    val entryType: EChatEntryType
+    val entryType: EChatEntryType?
 
     /**
      * Gets a value indicating whether this message is from a limited account.

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamfriends/callback/PersonaStatesCallback.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamfriends/callback/PersonaStatesCallback.kt
@@ -30,7 +30,7 @@ class PersonaStatesCallback(friend: CMsgClientPersonaState.Friend) : CallbackMsg
     /**
      * Gets the state.
      */
-    val state: EPersonaState = EPersonaState.from(friend.personaState)
+    val state: EPersonaState? = EPersonaState.from(friend.personaState)
 
     /**
      * Gets the state flags.

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamgameserver/callback/TicketAuthCallback.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamgameserver/callback/TicketAuthCallback.kt
@@ -32,7 +32,7 @@ class TicketAuthCallback(packetMsg: IPacketMsg) : CallbackMsg() {
     /**
      * @return the auth session response
      */
-    val authSessionResponse: EAuthSessionResponse
+    val authSessionResponse: EAuthSessionResponse?
 
     /**
      * @return the ticket CRC

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamuser/callback/WalletInfoCallback.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamuser/callback/WalletInfoCallback.kt
@@ -20,7 +20,7 @@ class WalletInfoCallback(packetMsg: IPacketMsg) : CallbackMsg() {
     /**
      * Gets the currency code for this wallet.
      */
-    val currency: ECurrencyCode
+    val currency: ECurrencyCode?
 
     /**
      * Gets the balance of the wallet as a 32-bit integer, in cents.

--- a/src/main/java/in/dragonbra/javasteam/steam/handlers/steamuserstats/callback/FindOrCreateLeaderboardCallback.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/handlers/steamuserstats/callback/FindOrCreateLeaderboardCallback.kt
@@ -33,12 +33,12 @@ class FindOrCreateLeaderboardCallback(packetMsg: IPacketMsg?) : CallbackMsg() {
     /**
      * Gets the sort method to use for this leaderboard.
      */
-    val sortMethod: ELeaderboardSortMethod
+    val sortMethod: ELeaderboardSortMethod?
 
     /**
      * Gets the display type for this leaderboard.
      */
-    val displayType: ELeaderboardDisplayType
+    val displayType: ELeaderboardDisplayType?
 
     init {
         val msg = ClientMsgProtobuf<CMsgClientLBSFindOrCreateLBResponse.Builder>(


### PR DESCRIPTION
### Description
Some Enum.from() methods can return null if no condition matches, so instead of forcing non-null to these values, we can allow null or fallback to a safe value. 

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary