### PR TITLE
AsyncJob fail when client disconnected

### DIFF
--- a/src/main/java/in/dragonbra/javasteam/steam/CMClient.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/CMClient.java
@@ -134,6 +134,14 @@ public abstract class CMClient {
     }
 
     /**
+     * Debugging only method:
+     * Do not use this directly.
+     */
+    public void setIsConnected(boolean value) {
+        isConnected = value;
+    }
+
+    /**
      * Connects this client to a Steam3 server. This begins the process of connecting and encrypting the data channel
      * between the client and the server. Results are returned asynchronously in a {@link in.dragonbra.javasteam.steam.steamclient.callbacks.ConnectedCallback ConnectedCallback}. If the
      * server that SteamKit attempts to connect to is down, a {@link in.dragonbra.javasteam.steam.steamclient.callbacks.DisconnectedCallback DisconnectedCallback} will be posted instead.

--- a/src/main/java/in/dragonbra/javasteam/steam/steamclient/SteamClient.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/steamclient/SteamClient.kt
@@ -204,6 +204,11 @@ class SteamClient @JvmOverloads constructor(
     }
 
     fun startJob(job: AsyncJob) {
+        if (!isConnected) {
+            job.setFailed(dueToRemoteFailure = true)
+            return
+        }
+
         jobManager.startJob(job)
     }
 //endregion

--- a/src/test/java/in/dragonbra/javasteam/ConnectedSteamClient.java
+++ b/src/test/java/in/dragonbra/javasteam/ConnectedSteamClient.java
@@ -1,0 +1,12 @@
+package in.dragonbra.javasteam;
+
+import in.dragonbra.javasteam.steam.steamclient.SteamClient;
+
+public class ConnectedSteamClient {
+    public static SteamClient get() {
+        var client = new SteamClient();
+        client.setIsConnected(true);
+
+        return client;
+    }
+}


### PR DESCRIPTION
### Description

Originally from SK issue 1531 and SK PR 1532

> AsyncJobManager shoudn't accept new jobs after SetTimeoutsEnabled(false) called.
An AsyncJob should cancel immidiatly because there is no chance to be completed(we are disconnected at this point) and also no options to be canceled because the calcellation timer is stopped.

Also added `isCompletedExceptionally` on most Job tests. With farily recent fixes, this seems to be working correctly for all but 2 tests. 

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
