### PR TITLE
Ossrh sunset migration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -129,8 +129,13 @@ dependencies {
 
 /* Artifact publishing */
 nexusPublishing {
+    // OSSRH reaches EOL on June 30, 2025
+    // https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration
     repositories {
         sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+
             val ossrhUsername: String by project
             val ossrhPassword: String by project
             username = ossrhUsername

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,22 +6,22 @@
 [versions]
 # Java / Kotlin versions
 java = "11"
-kotlin = "2.1.10" # https://kotlinlang.org/docs/releases.html#release-details
+kotlin = "2.1.20" # https://kotlinlang.org/docs/releases.html#release-details
 dokka = "2.0.0" # https://mvnrepository.com/artifact/org.jetbrains.dokka/dokka-gradle-plugin
-kotlinter = "5.0.1" # https://plugins.gradle.org/plugin/org.jmailen.kotlinter
+kotlinter = "5.0.2" # https://plugins.gradle.org/plugin/org.jmailen.kotlinter
 
 # Standard Library versions
 bouncyCastle = "1.80" # https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk18on
-commons-io = "2.18.0" # https://mvnrepository.com/artifact/commons-io/commons-io
+commons-io = "2.19.0" # https://mvnrepository.com/artifact/commons-io/commons-io
 commons-lang3 = "3.17.0" # https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
 commons-validator = "1.9.0" # https://mvnrepository.com/artifact/commons-validator/commons-validator
-gson = "2.12.1" # https://mvnrepository.com/artifact/com.google.code.gson/gson
-jacoco = "0.8.12" # https://www.eclemma.org/jacoco
-kotlin-coroutines = "1.10.1" # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-core
+gson = "2.13.1" # https://mvnrepository.com/artifact/com.google.code.gson/gson
+jacoco = "0.8.13" # https://www.eclemma.org/jacoco
+kotlin-coroutines = "1.10.2" # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-core
 okHttp = "5.0.0-alpha.14" # https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp
-protobuf = "4.29.3" # https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java
-protobuf-gradle = "0.9.4" # https://mvnrepository.com/artifact/com.google.protobuf/protobuf-gradle-plugin
-publishPlugin = "1.3.0" # https://mvnrepository.com/artifact/io.github.gradle-nexus/publish-plugin
+protobuf = "4.30.2" # https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java
+protobuf-gradle = "0.9.5" # https://mvnrepository.com/artifact/com.google.protobuf/protobuf-gradle-plugin
+publishPlugin = "2.0.0" # https://mvnrepository.com/artifact/io.github.gradle-nexus/publish-plugin
 qrCode = "1.0.1" # https://mvnrepository.com/artifact/pro.leaco.qrcode/console-qrcode
 xz = "1.10" # https://mvnrepository.com/artifact/org.tukaani/xz
 


### PR DESCRIPTION
### Description
OSSRH is being sunsetted on June 30th and migrating to the Central Publishing Portal will need to happen to continue publishing.

- Update dependencies to publish an actual snapshot. 

gradle-nexus/publish-plugin doesn't have proper support for it out of the box, but that can be fixed by manually setting the staging and snapshot urls accordingly. New user tokens also needed to be generated. 

- TODO: Our wiki page will need to be updated to reflect the new changes. 
https://github.com/Longi94/JavaSteam/wiki/Publishing-Artifacts-to-Maven

- Note: Snapshots seems to be working fine as-as https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/in/dragonbra/javasteam/

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
