### PR TITLE
Explicitly set Kotlin JVM target

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.gradle.kotlin.dsl.invoke
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jmailen.gradle.kotlinter.tasks.FormatTask
 import org.jmailen.gradle.kotlinter.tasks.LintTask
 
@@ -30,6 +31,12 @@ java {
     sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
     targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
     withSourcesJar()
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.fromTarget(libs.versions.java.get()))
+    }
 }
 
 /* Protobufs */


### PR DESCRIPTION
### Description
Specifies the JVM target for Kotlin, should fix #339 

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [ ] Samples run successfully
   (I don't know how to check this)
- [ ] Extended the README / documentation, if necessary
