### PR TITLE
Post client disconnection callback before cancelling jobs

### DIFF
--- a/src/main/java/in/dragonbra/javasteam/networking/steam3/WebSocketConnection.kt
+++ b/src/main/java/in/dragonbra/javasteam/networking/steam3/WebSocketConnection.kt
@@ -117,9 +117,9 @@ class WebSocketConnection :
 
                 job.cancelChildren()
             }
-        }
 
-        onDisconnected(userInitiated)
+            onDisconnected(userInitiated)
+        }
     }
 
     override fun send(data: ByteArray) {

--- a/src/main/java/in/dragonbra/javasteam/steam/CMClient.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/CMClient.java
@@ -96,7 +96,8 @@ public abstract class CMClient {
     private final EventHandler<DisconnectedEventArgs> disconnected = new EventHandler<>() {
         @Override
         public void handleEvent(Object sender, DisconnectedEventArgs e) {
-            logger.debug("EventHandler `disconnected` called");
+            logger.debug("EventHandler `disconnected` called. User Initiated: " + e.isUserInitiated() +
+                    ", Expected Disconnection: " + expectDisconnection);
 
             isConnected = false;
 

--- a/src/main/java/in/dragonbra/javasteam/steam/steamclient/SteamClient.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/steamclient/SteamClient.kt
@@ -265,14 +265,14 @@ class SteamClient @JvmOverloads constructor(
     override fun onClientDisconnected(userInitiated: Boolean) {
         super.onClientDisconnected(userInitiated)
 
+        postCallback(DisconnectedCallback(userInitiated))
+
         // if we are disconnected, cancel all pending jobs
         jobManager.cancelPendingJobs()
 
         jobManager.setTimeoutsEnabled(false)
 
         clearHandlerCaches()
-
-        postCallback(DisconnectedCallback(userInitiated))
     }
 
     fun clearHandlerCaches() {


### PR DESCRIPTION
### Description

From SK PR 1542: 

> After PR 1532, if you have some jobs running in a loop that gets cancelled on a disconnected callback, it is now possible to get into a loop where it will keep trying to send jobs, and instantly fail them.

Also fixed potential race condition in WebSocketConnection.

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
