### PR TITLE
add SteamOS and LegionGoS to EGamingDeviceType

### DIFF
--- a/src/main/steamd/in/dragonbra/javasteam/enums.steamd
+++ b/src/main/steamd/in/dragonbra/javasteam/enums.steamd
@@ -1685,5 +1685,7 @@ public enum EGamingDeviceType
 
 	Handheld = 512;
 	Phone = 528; // Handheld + 16
+	SteamOS = 541; // Handheld + 29
 	SteamDeck = 544; // Handheld + 32
+	LegionGoS = 545; // Handheld + 33
 }


### PR DESCRIPTION
### Description
add SteamOS and LegionGoS to EGamingDeviceType

From SK PR 1574

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
