### PR TITLE
Promote CS and Deadlock to Maven

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 
 allprojects {
     group = "in.dragonbra"
-    version = "1.7.0"
+    version = "1.7.1-SNAPSHOT"
 }
 
 repositories {

--- a/javasteam-cs/build.gradle.kts
+++ b/javasteam-cs/build.gradle.kts
@@ -30,4 +30,40 @@ dependencies {
     implementation(libs.protobuf.java)
 }
 
-// TODO promote to actual lib?
+/* Artifact publishing */
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            from(components["java"])
+            pom {
+                name = "JavaSteam-cs"
+                packaging = "jar"
+                description = "CS classes for JavaSteam."
+                url = "https://github.com/Longi94/JavaSteam"
+                inceptionYear = "2025"
+                scm {
+                    connection = "scm:git:git://github.com/Longi94/JavaSteam.git"
+                    developerConnection = "scm:git:ssh://github.com:Longi94/JavaSteam.git"
+                    url = "https://github.com/Longi94/JavaSteam/tree/master"
+                }
+                licenses {
+                    license {
+                        name = "MIT License"
+                        url = "https://www.opensource.org/licenses/mit-license.php"
+                    }
+                }
+                developers {
+                    developer {
+                        id = "Longi"
+                        name = "Long Tran"
+                        email = "lngtrn94@gmail.com"
+                    }
+                }
+            }
+        }
+    }
+}
+
+signing {
+    sign(publishing.publications["mavenJava"])
+}

--- a/javasteam-deadlock/build.gradle.kts
+++ b/javasteam-deadlock/build.gradle.kts
@@ -30,4 +30,40 @@ dependencies {
     implementation(libs.protobuf.java)
 }
 
-// TODO promote to actual lib?
+/* Artifact publishing */
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            from(components["java"])
+            pom {
+                name = "JavaSteam-deadlock"
+                packaging = "jar"
+                description = "Deadlock classes for JavaSteam."
+                url = "https://github.com/Longi94/JavaSteam"
+                inceptionYear = "2025"
+                scm {
+                    connection = "scm:git:git://github.com/Longi94/JavaSteam.git"
+                    developerConnection = "scm:git:ssh://github.com:Longi94/JavaSteam.git"
+                    url = "https://github.com/Longi94/JavaSteam/tree/master"
+                }
+                licenses {
+                    license {
+                        name = "MIT License"
+                        url = "https://www.opensource.org/licenses/mit-license.php"
+                    }
+                }
+                developers {
+                    developer {
+                        id = "Longi"
+                        name = "Long Tran"
+                        email = "lngtrn94@gmail.com"
+                    }
+                }
+            }
+        }
+    }
+}
+
+signing {
+    sign(publishing.publications["mavenJava"])
+}


### PR DESCRIPTION
### Description
Enable CS and Deadlock protos to be maven libs.

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
