### PR TITLE
Add unrolled adler-32 checksum which is faster

### DIFF
--- a/src/main/java/in/dragonbra/javasteam/steam/cdn/DepotChunk.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/cdn/DepotChunk.kt
@@ -1,8 +1,8 @@
 package `in`.dragonbra.javasteam.steam.cdn
 
 import `in`.dragonbra.javasteam.types.ChunkData
+import `in`.dragonbra.javasteam.util.Adler32
 import `in`.dragonbra.javasteam.util.Strings
-import `in`.dragonbra.javasteam.util.Utils
 import `in`.dragonbra.javasteam.util.VZipUtil
 import `in`.dragonbra.javasteam.util.VZstdUtil
 import `in`.dragonbra.javasteam.util.ZipUtil
@@ -126,7 +126,7 @@ object DepotChunk {
             )
         }
 
-        val dataCrc = Utils.adlerHash(destination.sliceArray(0 until writtenDecompressed))
+        val dataCrc = Adler32.calculate(destination.sliceArray(0 until writtenDecompressed))
 
         if (dataCrc != info.checksum) {
             throw IOException("Processed data checksum is incorrect ($dataCrc != ${info.checksum})! Downloaded depot chunk is corrupt or invalid/wrong depot key?")

--- a/src/main/java/in/dragonbra/javasteam/steam/contentdownloader/ContentDownloader.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/contentdownloader/ContentDownloader.kt
@@ -13,6 +13,7 @@ import `in`.dragonbra.javasteam.types.ChunkData
 import `in`.dragonbra.javasteam.types.DepotManifest
 import `in`.dragonbra.javasteam.types.FileData
 import `in`.dragonbra.javasteam.types.KeyValue
+import `in`.dragonbra.javasteam.util.Adler32
 import `in`.dragonbra.javasteam.util.SteamKitWebRequestException
 import `in`.dragonbra.javasteam.util.Strings
 import `in`.dragonbra.javasteam.util.Utils
@@ -421,7 +422,7 @@ class ContentDownloader(val steamClient: SteamClient) {
                             val tmp = ByteArray(match.oldChunk.uncompressedLength)
                             fsOld.readNBytesCompat(tmp, 0, tmp.size)
 
-                            val adler = Utils.adlerHash(tmp)
+                            val adler = Adler32.calculate(tmp)
                             if (adler != match.oldChunk.checksum) {
                                 neededChunks.add(match.newChunk)
                             } else {

--- a/src/main/java/in/dragonbra/javasteam/util/Adler32.kt
+++ b/src/main/java/in/dragonbra/javasteam/util/Adler32.kt
@@ -1,0 +1,46 @@
+package `in`.dragonbra.javasteam.util
+
+// See https://www.rfc-editor.org/rfc/rfc1950.html
+object Adler32 {
+
+    // Largest prime smaller than 65536
+    private const val BASE = 65521
+
+    // NMAX is the largest n such that 255n(n+1)/2 + (n+1)(BASE-1) <= 2^32-1
+    private const val NMAX = 5552
+
+    /**
+     * Calculates the Adler32 checksum with the bytes taken from the span using zero as the initial seed.
+     */
+    @JvmStatic
+    fun calculate(buffer: ByteArray): Int = calculate(0, buffer)
+
+    /**
+     * Calculates the Adler32 checksum with the bytes taken from the span.
+     * @param adler The input Adler32 value.
+     * @param buffer The readonly span of bytes.
+     * @return The [Int].
+     */
+    @JvmStatic
+    fun calculate(adler: Int, buffer: ByteArray): Int {
+        var s1 = adler and 0xFFFF
+        var s2 = (adler ushr 16) and 0xFFFF
+        var pos = 0
+
+        while (pos < buffer.size) {
+            val len = minOf(buffer.size - pos, NMAX)
+            val end = pos + len
+
+            while (pos < end) {
+                s1 += buffer[pos].toInt() and 0xFF
+                s2 += s1
+                pos++
+            }
+
+            s1 %= BASE
+            s2 %= BASE
+        }
+
+        return (s2 shl 16) or s1
+    }
+}

--- a/src/main/java/in/dragonbra/javasteam/util/Adler32.kt
+++ b/src/main/java/in/dragonbra/javasteam/util/Adler32.kt
@@ -3,44 +3,91 @@ package `in`.dragonbra.javasteam.util
 // See https://www.rfc-editor.org/rfc/rfc1950.html
 object Adler32 {
 
-    // Largest prime smaller than 65536
+    /**
+     * Base modulo value - largest prime smaller than 65536
+     */
     private const val BASE = 65521
 
-    // NMAX is the largest n such that 255n(n+1)/2 + (n+1)(BASE-1) <= 2^32-1
+    /**
+     * NMAX is the largest n such that 255n(n+1)/2 + (n+1)(BASE-1) <= 2^32-1
+     */
     private const val NMAX = 5552
 
     /**
-     * Calculates the Adler32 checksum with the bytes taken from the span using zero as the initial seed.
+     * Calculates the Adler32 checksum with the bytes taken from the span using `one` as the initial seed.
      */
     @JvmStatic
     fun calculate(buffer: ByteArray): Int = calculate(0, buffer)
 
     /**
-     * Calculates the Adler32 checksum with the bytes taken from the span.
-     * @param adler The input Adler32 value.
-     * @param buffer The readonly span of bytes.
-     * @return The [Int].
+     * Calculates the Adler32 checksum with the bytes taken from the [ByteArray]
+     * @param adler The input Adler32 value. (use 1 for initial calculation)
+     * @param buffer The byte array to process
+     * @return The updated Adler-32 checksum
      */
     @JvmStatic
     fun calculate(adler: Int, buffer: ByteArray): Int {
-        var s1 = adler and 0xFFFF
-        var s2 = (adler ushr 16) and 0xFFFF
-        var pos = 0
+        var s1 = (adler and 0xFFFF).toLong()
+        var s2 = ((adler ushr 16) and 0xFFFF).toLong()
 
-        while (pos < buffer.size) {
-            val len = minOf(buffer.size - pos, NMAX)
-            val end = pos + len
+        var offset = 0
+        val length = buffer.size
 
-            while (pos < end) {
-                s1 += buffer[pos].toInt() and 0xFF
+        while (offset < length) {
+            val k = minOf(length - offset, NMAX)
+            val chunkEnd = offset + k
+            var remaining = k
+
+            // Unroll by 16 bytes for maximum performance
+            while (remaining >= 16) {
+                s1 += (buffer[offset].toInt() and 0xFF).toLong()
                 s2 += s1
-                pos++
+                s1 += (buffer[offset + 1].toInt() and 0xFF).toLong()
+                s2 += s1
+                s1 += (buffer[offset + 2].toInt() and 0xFF).toLong()
+                s2 += s1
+                s1 += (buffer[offset + 3].toInt() and 0xFF).toLong()
+                s2 += s1
+                s1 += (buffer[offset + 4].toInt() and 0xFF).toLong()
+                s2 += s1
+                s1 += (buffer[offset + 5].toInt() and 0xFF).toLong()
+                s2 += s1
+                s1 += (buffer[offset + 6].toInt() and 0xFF).toLong()
+                s2 += s1
+                s1 += (buffer[offset + 7].toInt() and 0xFF).toLong()
+                s2 += s1
+                s1 += (buffer[offset + 8].toInt() and 0xFF).toLong()
+                s2 += s1
+                s1 += (buffer[offset + 9].toInt() and 0xFF).toLong()
+                s2 += s1
+                s1 += (buffer[offset + 10].toInt() and 0xFF).toLong()
+                s2 += s1
+                s1 += (buffer[offset + 11].toInt() and 0xFF).toLong()
+                s2 += s1
+                s1 += (buffer[offset + 12].toInt() and 0xFF).toLong()
+                s2 += s1
+                s1 += (buffer[offset + 13].toInt() and 0xFF).toLong()
+                s2 += s1
+                s1 += (buffer[offset + 14].toInt() and 0xFF).toLong()
+                s2 += s1
+                s1 += (buffer[offset + 15].toInt() and 0xFF).toLong()
+                s2 += s1
+
+                offset += 16
+                remaining -= 16
             }
+
+            for (i in 0 until remaining) {
+                s1 += (buffer[offset + i].toInt() and 0xFF).toLong()
+                s2 += s1
+            }
+
+            offset = chunkEnd
 
             s1 %= BASE
             s2 %= BASE
         }
 
-        return (s2 shl 16) or s1
+        return ((s2 shl 16) or s1).toInt()
     }
 }

--- a/src/main/java/in/dragonbra/javasteam/util/Utils.java
+++ b/src/main/java/in/dragonbra/javasteam/util/Utils.java
@@ -195,20 +195,6 @@ public class Utils {
     }
 
     /**
-     * Performs an Adler32 on the given input
-     */
-    public static int adlerHash(byte[] input) {
-        int a = 0, b = 0;
-        for (byte value : input) {
-            // Use bitwise AND with 0xFF to treat byte as unsigned
-            a = (a + (value & 0xFF)) % 65521;
-            b = (b + a) % 65521;
-        }
-
-        return a | (b << 16);
-    }
-
-    /**
      * Validate a file against Steam3 Chunk data
      *
      * @param fs        FileInputStream to read from
@@ -235,7 +221,7 @@ public class Utils {
                 tempChunk = chunk;
             }
 
-            int adler = adlerHash(tempChunk);
+            int adler = Adler32.calculate(tempChunk);
             if (adler != data.getChecksum()) {
                 neededChunks.add(data);
             }

--- a/src/test/java/in/dragonbra/javasteam/util/Alder32Test.java
+++ b/src/test/java/in/dragonbra/javasteam/util/Alder32Test.java
@@ -1,0 +1,175 @@
+package in.dragonbra.javasteam.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Random;
+
+public class Alder32Test {
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2})
+    void returnsCorrectWhenEmpty(int input) {
+        var emptyArray = new byte[0];
+        var result = Adler32.calculate(input, emptyArray);
+        Assertions.assertEquals(input, result);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 8, 215, 1024, 1024 + 15, 2034, 4096})
+    void matchesReference(int length) {
+        final var seed = 0;
+        var data = new byte[length];
+        new Random().nextBytes(data);
+
+        var expected = referenceImplementation(data);
+        var actual = Adler32.calculate(seed, data);
+
+        Assertions.assertEquals(expected, actual);
+    }
+
+    // Additional benchmarking
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test
+    void benchmarkSmallBuffers() {
+        final int iterations = 100_000;
+        final int bufferSize = 1024; // 1KB buffers
+
+        var data = new byte[bufferSize];
+        new Random(12345).nextBytes(data); // Fixed seed for consistency
+
+        // Warmup
+        for (int i = 0; i < 1000; i++) {
+            referenceImplementation(data);
+            Adler32.calculate(data);
+        }
+
+        // Benchmark reference implementation
+        long startTime = System.nanoTime();
+        for (int i = 0; i < iterations; i++) {
+            referenceImplementation(data);
+        }
+        long referenceTime = System.nanoTime() - startTime;
+
+        // Benchmark optimized implementation
+        startTime = System.nanoTime();
+        for (int i = 0; i < iterations; i++) {
+            Adler32.calculate(data);
+        }
+        long optimizedTime = System.nanoTime() - startTime;
+
+        double speedup = (double) referenceTime / optimizedTime;
+
+        System.out.printf("Small Buffer Benchmark (%d bytes, %d iterations):%n", bufferSize, iterations);
+        System.out.printf("Reference implementation: %.2f ms%n", referenceTime / 1_000_000.0);
+        System.out.printf("Optimized implementation: %.2f ms%n", optimizedTime / 1_000_000.0);
+        System.out.printf("Speedup: %.2fx%n", speedup);
+        System.out.println();
+
+        // Assert that optimized version is faster (allow for some measurement variance)
+        Assertions.assertTrue(speedup > 0.8,
+                String.format("Expected optimized version to be competitive, but speedup was only %.2fx", speedup));
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test
+    void benchmarkLargeBuffers() {
+        final int iterations = 1_000;
+        final int bufferSize = 1024 * 1024; // 1MB buffers
+
+        var data = new byte[bufferSize];
+        new Random(54321).nextBytes(data); // Fixed seed for consistency
+
+        // Warmup
+        for (int i = 0; i < 10; i++) {
+            referenceImplementation(data);
+            Adler32.calculate(data);
+        }
+
+        // Benchmark reference implementation
+        long startTime = System.nanoTime();
+        for (int i = 0; i < iterations; i++) {
+            referenceImplementation(data);
+        }
+        long referenceTime = System.nanoTime() - startTime;
+
+        // Benchmark optimized implementation
+        startTime = System.nanoTime();
+        for (int i = 0; i < iterations; i++) {
+            Adler32.calculate(data);
+        }
+        long optimizedTime = System.nanoTime() - startTime;
+
+        double speedup = (double) referenceTime / optimizedTime;
+
+        System.out.printf("Large Buffer Benchmark (%d bytes, %d iterations):%n", bufferSize, iterations);
+        System.out.printf("Reference implementation: %.2f ms%n", referenceTime / 1_000_000.0);
+        System.out.printf("Optimized implementation: %.2f ms%n", optimizedTime / 1_000_000.0);
+        System.out.printf("Speedup: %.2fx%n", speedup);
+        System.out.println();
+
+        // Assert that optimized version is significantly faster for large buffers
+        Assertions.assertTrue(speedup > 1.0,
+                String.format("Expected optimized version to be faster for large buffers, but speedup was only %.2fx", speedup));
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test
+    void benchmarkVariousSizes() {
+        final int[] bufferSizes = {16, 64, 256, 1024, 4096, 16384, 65536};
+        final int baseIterations = 50_000;
+
+        System.out.println("Performance Comparison Across Buffer Sizes:");
+        System.out.println("Size\t\tReference(ms)\tOptimized(ms)\tSpeedup");
+        System.out.println("----\t\t-------------\t-------------\t-------");
+
+        for (int size : bufferSizes) {
+            var data = new byte[size];
+            new Random(size).nextBytes(data); // Different seed per size
+
+            // Adjust iterations based on buffer size to keep test time reasonable
+            int iterations = Math.max(1000, baseIterations / (size / 16));
+
+            // Warmup
+            for (int i = 0; i < Math.min(100, iterations / 10); i++) {
+                referenceImplementation(data);
+                Adler32.calculate(data);
+            }
+
+            // Benchmark reference
+            long startTime = System.nanoTime();
+            for (int i = 0; i < iterations; i++) {
+                referenceImplementation(data);
+            }
+            long referenceTime = System.nanoTime() - startTime;
+
+            // Benchmark optimized
+            startTime = System.nanoTime();
+            for (int i = 0; i < iterations; i++) {
+                Adler32.calculate(data);
+            }
+            long optimizedTime = System.nanoTime() - startTime;
+
+            double refMs = referenceTime / 1_000_000.0;
+            double optMs = optimizedTime / 1_000_000.0;
+            double speedup = (double) referenceTime / optimizedTime;
+
+            System.out.printf("%d\t\t%.2f\t\t%.2f\t\t%.2fx%n", size, refMs, optMs, speedup);
+        }
+        System.out.println();
+    }
+
+    private static int referenceImplementation(byte[] input) {
+        int a = 0, b = 0;
+        for (byte value : input) {
+            // Use bitwise AND with 0xFF to treat byte as unsigned
+            a = (a + (value & 0xFF)) % 65521;
+            b = (b + a) % 65521;
+        }
+
+        return a | (b << 16);
+    }
+}


### PR DESCRIPTION
### Description
From SK Commit f1dbcf4 and 3a7c46c

Also added additional benchmarks to ensure unrolled adler is better than the old Utils.adlerHash() method. 

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
