### PR TITLE
CMClient.handlemulti Fix

### DIFF
--- a/src/main/java/in/dragonbra/javasteam/steam/CMClient.java
+++ b/src/main/java/in/dragonbra/javasteam/steam/CMClient.java
@@ -24,14 +24,12 @@ import in.dragonbra.javasteam.util.event.EventHandler;
 import in.dragonbra.javasteam.util.event.ScheduledFunction;
 import in.dragonbra.javasteam.util.log.LogManager;
 import in.dragonbra.javasteam.util.log.Logger;
-import in.dragonbra.javasteam.util.stream.BinaryReader;
 import okio.Buffer;
 import okio.BufferedSource;
 import okio.GzipSource;
 import okio.Okio;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -336,8 +334,8 @@ public abstract class CMClient {
         }
 
         int rawEMsg = 0;
-        try (var reader = new BinaryReader(new ByteArrayInputStream(data))) {
-            rawEMsg = reader.readInt();
+        try (var buffer = new Buffer().write(data)) {
+             rawEMsg = buffer.readIntLe();
         } catch (IOException e) {
             logger.debug("Exception while getting EMsg code", e);
         }


### PR DESCRIPTION
### Description
My recent optimiztion for handleMulti() worked fine most of the time. Though I discovered when asking for a lot of PICS items it would show that it failed when parsing through zipped responses every so often during a fresh launch. It was kinda of seldom. 

This fix uses okio since it is a transitive dependency of okhttp. okio eats this stuff for breakfast as that what it does best. And doing some simple timing measures shows that it is a bit more performant than my attempt, so I'd like to add it here for a start to use okio in certain places. 

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
