### PR TITLE
Fix missing javadoc artifact.

### DIFF
--- a/javasteam-depotdownloader/build.gradle.kts
+++ b/javasteam-depotdownloader/build.gradle.kts
@@ -82,6 +82,7 @@ publishing {
     publications {
         create<MavenPublication>("mavenJava") {
             from(components["java"])
+            artifact(javadocJar)
             pom {
                 name = "JavaSteam-depotdownloader"
                 packaging = "jar"


### PR DESCRIPTION
### Description
1.8.0 failed to publish since depotdownloader was missing javadoc artifact. 

### Checklist
- [ ] Code compiles correctly
- [ ] All tests passing
- [ ] Samples run successfully
- [ ] Extended the README / documentation, if necessary
