### PR TITLE
cdn: 规范化 query 参数处理

### DIFF
--- a/src/main/java/in/dragonbra/javasteam/steam/cdn/Client.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/cdn/Client.kt
@@ -66,14 +66,8 @@ class Client(steamClient: SteamClient) : Closeable {
                 .addPathSegments(path.trimStart('/'))
 
             query?.let { queryString ->
-                if (queryString.isEmpty()) {
-                    null
-                } else {
-                    queryString.removePrefix("?")
-                }
-            }?.let { queryString ->
                 if (queryString.isNotEmpty()) {
-                    val params = queryString.split("&")
+                    val params = queryString.trimStart('?').split("&")
                     for (param in params) {
                         val keyValue = param.split("=", limit = 2)
                         if (keyValue.size == 2) {

--- a/src/main/java/in/dragonbra/javasteam/steam/cdn/Client.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/cdn/Client.kt
@@ -66,6 +66,12 @@ class Client(steamClient: SteamClient) : Closeable {
                 .addPathSegments(path.trimStart('/'))
 
             query?.let { queryString ->
+                if (queryString.isEmpty()) {
+                    null
+                } else {
+                    queryString.removePrefix("?")
+                }
+            }?.let { queryString ->
                 if (queryString.isNotEmpty()) {
                     val params = queryString.split("&")
                     for (param in params) {


### PR DESCRIPTION
### Description
his PR tightens query-string handling when building CDN request URLs in Client (steam/cdn).

Empty query: If the optional query argument is an empty string, it is treated as “no query” and no query parameters are appended (avoids pointless work and odd ?-only URLs).
Leading ?: If the string starts with ?, that prefix is stripped before splitting on &, so callers can pass either foo=bar or ?foo=bar and get the same parsed parameters.
No README or public API changes.

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [ ] Samples run successfully
- [ ] Extended the README / documentation, if necessary
