### PR TITLE
make requestAliasHistory() return AsyncJobSingle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 
 allprojects {
     group = "in.dragonbra"
-    version = "1.8.0"
+    version = "1.8.1-SNAPSHOT"
 }
 
 repositories {


### PR DESCRIPTION
### Description
make requestAliasHistory() return AsyncJobSingle

annotate methods in SteamFriends that are JavaSteam added

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Samples run successfully
- [x] Extended the README / documentation, if necessary
