### PR TITLE
Add CloudConfigStore protobuf service

### DIFF
--- a/src/main/proto/in/dragonbra/javasteam/protobufs/webui/service_cloudconfigstore.proto
+++ b/src/main/proto/in/dragonbra/javasteam/protobufs/webui/service_cloudconfigstore.proto
@@ -1,0 +1,57 @@
+import "in/dragonbra/javasteam/protobufs/steamclient/steammessages_unified_base.steamclient.proto";
+
+option java_package = "in.dragonbra.javasteam.protobufs.webui";
+
+option optimize_for = SPEED;
+option java_generic_services = false;
+
+message CCloudConfigStore_Change_Notification {
+  repeated .CCloudConfigStore_NamespaceVersion versions = 2;
+}
+
+message CCloudConfigStore_Download_Request {
+  repeated .CCloudConfigStore_NamespaceVersion versions = 1;
+}
+
+message CCloudConfigStore_Download_Response {
+  repeated .CCloudConfigStore_NamespaceData data = 1;
+}
+
+message CCloudConfigStore_Entry {
+  optional string key = 1;
+  optional bool is_deleted = 2;
+  optional string value = 3;
+  optional fixed32 timestamp = 4;
+  optional uint64 version = 5;
+}
+
+message CCloudConfigStore_NamespaceData {
+  optional uint32 enamespace = 1;
+  optional uint64 version = 2;
+  repeated .CCloudConfigStore_Entry entries = 3;
+  optional uint64 horizon = 4;
+}
+
+message CCloudConfigStore_NamespaceVersion {
+  optional uint32 enamespace = 1;
+  optional uint64 version = 2;
+}
+
+message CCloudConfigStore_Upload_Request {
+  repeated .CCloudConfigStore_NamespaceData data = 1;
+}
+
+message CCloudConfigStore_Upload_Response {
+  repeated .CCloudConfigStore_NamespaceVersion versions = 1;
+}
+
+service CloudConfigStore {
+  // bConstMethod=true, ePrivilege=1
+  rpc Download (.CCloudConfigStore_Download_Request) returns (.CCloudConfigStore_Download_Response);
+  // ePrivilege=1
+  rpc Upload (.CCloudConfigStore_Upload_Request) returns (.CCloudConfigStore_Upload_Response);
+}
+
+service CloudConfigStoreClient {
+  rpc NotifyChange (.CCloudConfigStore_Change_Notification) returns (.NoResponse);
+}

--- a/src/test/java/in/dragonbra/javasteam/rpc/UnifiedInterfaceTest.kt
+++ b/src/test/java/in/dragonbra/javasteam/rpc/UnifiedInterfaceTest.kt
@@ -82,7 +82,9 @@ class UnifiedInterfaceTest {
             "PublishedFileClient.kt",
 
             // WebUI
-            "ClientComm.kt"
+            "ClientComm.kt",
+            "CloudConfigStore.kt",
+            "CloudConfigStoreClient.kt",
         )
     }
 }


### PR DESCRIPTION
JavaSteam ships the Steam Cloud (file storage) messages but not CloudConfigStore, which is the namespace where things like user-defined game collections live. Without it there's no way to call CloudConfigStore.Download from a UnifiedMessages handler, so I had to hand-roll the protobuf + a service stub downstream.

This adds steammessages_cloudconfigstore.steamclient.proto (messages + the CloudConfigStore / CloudConfigStoreClient services), mirroring the sibling steammessages_cloud.steamclient.proto layout. The message definitions come straight from SteamDB's Protobufs.

The RPC generator picks it up automatically (no extra wiring needed):

    [steammessages_cloudconfigstore.steamclient.proto] - found "CloudConfigStore", which has 2 methods
    [steammessages_cloudconfigstore.steamclient.proto] - found "CloudConfigStoreClient", which has 1 methods

`generateProto` + `generateRpcMethods` build clean and produce SteammessagesCloudconfigstoreSteamclient plus the CloudConfigStore service stub.